### PR TITLE
Remove publishing flow from admin but add publish tag

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -6,7 +6,7 @@ backend:
   repo: singaround/songbook
 
 # Uncomment below to enable drafts
-publish_mode: editorial_workflow
+# publish_mode: editorial_workflow
 
 media_folder: "static/img" # Media files will be stored in the repo under images/uploads
 
@@ -37,6 +37,7 @@ collections:
           default: song,
         }
       - { label: Title, name: title, widget: string }
+      - { label: Published, name: published, widget: boolean, default: false, required: false}
       - { label: Words by, name: wordsBy, widget: string, required: false }
       - { label: Tune by, name: tuneBy, widget: string, required: false }
       - { label: Chorus first line, name: chorusLine, widget: string, required: false }
@@ -46,6 +47,7 @@ collections:
       - { label: Publish Date, name: date, widget: datetime, required: false }
       - { label: Description, name: description, widget: markdown, required: false }
       - { label: Words, name: body, widget: markdown }
+
 
   # Our pages e.g. About
   - name: "pages"


### PR DESCRIPTION
The publishing flow in Netlify CMS is great, but a bit slow when
all the data exists, so we're using our publish field in the MD and
ditching the git-based flow (with PRs as drafts)