### PR TITLE
Remove ineffectual height and fix image width.

### DIFF
--- a/_includes/assets/css/inline.css
+++ b/_includes/assets/css/inline.css
@@ -23,6 +23,10 @@ body {
 	background-color: var(--white);
 }
 
+.navbar-logo {
+	width: 23px;
+}
+
 /* Contact Form */
 form {
   display: grid;

--- a/_includes/components/nav.njk
+++ b/_includes/components/nav.njk
@@ -1,7 +1,7 @@
 <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <a class="navbar-item" href="/">
-      <img src="/static/img/auntie-shanty-logo.svg" height="60">
+      <img class="navbar-logo" src="/static/img/auntie-shanty-logo.svg">
     </a>
 
     <div class="navbar-item">


### PR DESCRIPTION
This prevents the navbar contents shifting right when the image loads.
This is particularly noticable when you hard-refresh the page on slow
connections.