### PR TITLE
Add Google Site search as a starter 

### DIFF
--- a/_includes/layouts/songbook.njk
+++ b/_includes/layouts/songbook.njk
@@ -4,8 +4,19 @@ section: songbook
 permalink: /songbook/index.html
 ---
 <h1>{{ title }}</h1>
-
 {{ layoutContent | safe }}
-
+Search the songs:
+<script>
+  (function() {
+    var cx = '018245618682331088118:getooo00wtq';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>
 {% set songslist = collections.numberedSongs %}
 {% include "components/songslist.njk" %}


### PR DESCRIPTION
@CaptainSharks @RogerioY here's a quick-and-dirty song search on the songs page - didn't want to clutter the nav with another search box if this works well enough, but I guess we could also put search in the hamburger menu?

How do you think it feels on the phone?

Todo:
- [ ] Remove the 'we haven't got as far as search' note on the Index pages
- [ ] Avoid turning up songs that haven't been 'published' properly (or template these as 'do not sing')?
- [ ] Decide how we feel about loading Google JS into the page versus having a box that will take out out somewhere else