### PR TITLE
admin: update the branch to 'main'

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -4,6 +4,7 @@
 backend:
   name: github
   repo: singaround/songbook
+  branch: main
 
 # Uncomment below to enable drafts
 # publish_mode: editorial_workflow


### PR DESCRIPTION
We switched in GitHub but the CMS is still looking for 'master', the default branch name, so we have no collections present.