### PR TITLE
Fix chorus formattting

### DIFF
--- a/songs/All-For-Me-Grog.md
+++ b/songs/All-For-Me-Grog.md
@@ -12,11 +12,11 @@ date: 2019-03-07T08:05:12.000Z
 description: We've changed the chorus so that we're spending the money **with**
   the lassies and not **on** the lassies.
 ---
-> And it's all for me grog, me jolly, jolly grog\
-> All for my beer and tobacco\
-> Well, I spent all my tin\
-> With the lassies drinking gin\
-> Far across the Western Ocean I must wander
+> ***And it's all for me grog, me jolly, jolly grog***\
+> ***All for my beer and tobacco***\
+> ***Well, I spent all my tin***\
+> ***With the lassies drinking gin***\
+> ***Far across the Western Ocean I must wander***
 
 Where are my boots, my nogging, nogging boots\
 ***All gone for beer and tobacco***\
@@ -24,7 +24,7 @@ Well the soles they are worn out\
 And the heels are kicked about\
 And the toes are looking out for better weather
 
-> And it's all for me grog, me jolly, jolly grog...
+> ***And it's all for me grog, me jolly, jolly grog...***
 
 Where is my shirt, my nogging, nogging shirt\
 ***All gone for beer and tobacco***\
@@ -32,7 +32,7 @@ Well the sleeves they got worn out\
 And the collar's turned about\
 And the tail is looking out for better weather
 
-> And it's all for me grog, me jolly, jolly grog...
+> ***And it's all for me grog, me jolly, jolly grog...***
 
 Where is my bed, my nogging, nogging bed\
 ***All gone for beer and tobacco***\
@@ -40,7 +40,7 @@ Well the sheets they got all worn\
 And the mattress got all torn\
 And the springs are looking out for better weather
 
-> And it's all for me grog, me jolly, jolly grog...
+> ***And it's all for me grog, me jolly, jolly grog...***
 
 Well he's sick in the head and he hasn't been to bed\
 Since first he came ashore with his plunder\
@@ -48,4 +48,4 @@ He's seen centipedes and snakes\
 Till his head is full of aches\
 And we hope to take a path to way up yonder
 
-> And it's all for me grog, me jolly, jolly grog...
+> ***And it's all for me grog, me jolly, jolly grog...***

--- a/songs/Barretts-Privateers.md
+++ b/songs/Barretts-Privateers.md
@@ -14,54 +14,54 @@ description: >-
  This is quite a long one, so if you decide to lead this, be prepared! It doesn't hurt to keep it pacey!
 ---
 Oh, the year was 1778\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 A letter of marque came from the king\
 To the scummiest vessel I've ever seen
 
-> _God damn them all! I was told_\
-> _We'd cruise the seas for American gold_\
-> _We'd fire no guns, shed no tears_\
-> _But I'm a broken man on a Halifax pier_\
-> _The last of Barrett's Privateers_
+> ***God damn them all! I was told***\
+> ***We'd cruise the seas for American gold***\
+> ***We'd fire no guns, shed no tears***\
+> ***But I'm a broken man on a Halifax pier***\
+> ***The last of Barrett's Privateers***
 
 Oh, Elcid Barrett cried the town\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 For twenty brave men all fishermen who\
 Would make for him the Antelope's crew
 
-> _God damn them all! I was told..._
+> ***God damn them all! I was told...***
 
 The Antelope sloop was a sickening sight\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 She'd a list to the port and her sails in rags\
 And the cook in the scuppers with the staggers and jags
 
 On the King's birthday we put to sea\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 We were ninety-one days to Montego Bay\
 Pumping like madmen all the way
 
 On the ninety-sixth day we sailed again\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 When a bloody great Yankee hove in sight\
 With our cracked four pounders we made to fight
 
 Now the Yankee lay low down with gold\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 She was broad and fat and loose in the stays\
 But to catch her took the Antelope two whole days
 
 Then at length we stood two cables away\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 Our cracked four pounders made an awful din\
 But with one fat ball, the Yank stove us in
 
 The Antelope shook and pitched on her side\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 Barrett was smashed like a bowl of eggs\
 And the main truck carried off both me legs
 
 So here I lay in my twenty-third year\
-_How I wish I was in Sherbrooke now_\
+***How I wish I was in Sherbrooke now***\
 It's been six years since we sailed away\
 And I just made Halifax yesterday

--- a/songs/Ben-Backstay.md
+++ b/songs/Ben-Backstay.md
@@ -19,13 +19,13 @@ And when unto his summons\
 We did not well attend,\
 No lad than he more merrily\
 Could handle a rope's end\
-_Could handle a rope's end_\
-_Could handle a rope's end!_
+***Could handle a rope's end***\
+***Could handle a rope's end!***
 
-> _Singing chip cho, cherry cho,_\
-> _Fol de riddle ido,_\
-> _Chip cho, cherry cho,_\
-> _Fol de riddle day._
+> ***Singing chip cho, cherry cho,***\
+> ***Fol de riddle ido,***\
+> ***Chip cho, cherry cho,***\
+> ***Fol de riddle day.***
 
 It chanced one day our captain,\
 A very jolly dog,\
@@ -36,10 +36,10 @@ Ben Backstay he got tipsy,\
 Unto his heart's content,\
 And being half-seas over,\
 Right overboard he went\
-_Right overboard he went_\
-_Right overboard he went._
+***Right overboard he went***\
+***Right overboard he went.***
 
-> _Singing chip cho, cherry cho..._
+> ***Singing chip cho, cherry cho...***
 
 A shark was on the larboard bow\
 Sharks don't on manners stand,\
@@ -50,10 +50,10 @@ We heaved Ben out some tackling,\
 Of saving him in hopes;\
 But the shark he bit his head off,\
 So he couldn't see the ropes\
-_So he couldn't see the ropes_\
-_So he couldn't see the ropes._
+***So he couldn't see the ropes***\
+***So he couldn't see the ropes.***
 
-> _Singing chip cho, cherry cho..._
+> ***Singing chip cho, cherry cho...***
 
 Without his head his ghost appeared\
 All on the briny lake:\
@@ -63,8 +63,8 @@ He piped all hands aloft and said;\
 By drinking grog I lost my life,\
 So lest my fate you meet,\
 Why, never mix your liquors, lads,\
-_But always drink them neat_\
-_But always drink them neat_\
-_But always drink them neat."_
+***But always drink them neat***\
+***But always drink them neat***\
+***But always drink them neat."***
 
-> _Singing chip cho, cherry cho..._
+> ***Singing chip cho, cherry cho...***

--- a/songs/Ben-kenobi-nobi.md
+++ b/songs/Ben-kenobi-nobi.md
@@ -13,31 +13,31 @@ description: >-
   This is a funny rewrite of John The Slacker, written by Les Barker
 ---
 I heard the R2D2 say\
-_Ben Kenobi, Nobi Too-Rye-Ay_\
+***Ben Kenobi, Nobi Too-Rye-Ay***\
 Millenium Falcon's on its way\
-_Ben Kenobi, Nobi Too-Rye-Ay_
+***Ben Kenobi, Nobi Too-Rye-Ay***
 
-> _Too-Rye-Ay, Oh, Too-Rye-Ay_\
-> _Ben Kenobi, Nobi Too-Rye-Ay_
+> ***Too-Rye-Ay, Oh, Too-Rye-Ay***\
+> ***Ben Kenobi, Nobi Too-Rye-Ay***
 
 Who taught Luke about the Force?\
-_Ben Kenobi, Nobi Too-Rye-Ay_\
+***Ben Kenobi, Nobi Too-Rye-Ay***\
 Who's the Fountain, who's the Source?\
-_Ben Kenobi, Nobi Too-Rye-Ay_
+***Ben Kenobi, Nobi Too-Rye-Ay***
 
-> _(Chorus)_
+> ***(Chorus)***
 
 Who does Alec Guinness play?\
 Who's not in The Darling Buds Of May?
 
-> _(Chorus)_
+> ***(Chorus)***
 
 Who stands next to Harrison Ford?\
 Carrying a bloody great big sword?
 
-> _(Chorus)_
+> ***(Chorus)***
 
 What comes after Jedi Day?\
 Jedi Night, so the old men say
 
-> _(Chorus x 2)_
+> ***(Chorus x 2)***

--- a/songs/Black-Ball-Line.md
+++ b/songs/Black-Ball-Line.md
@@ -16,41 +16,41 @@ description: >-
   Liverpool branch of the line operated from 1852 until 1871.
 ---
 In the Black Ball line I served my time\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 And that's the line where you can shine\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 The Black Ball Ships are good and true\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 They are the ships for me and you\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 For once there was a Black Ball ship\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 That fourteen knots an hour could clip\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 They'll carry you along through frost and snow\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 And take you where the wind don't blow\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 You will surely find a rich gold mine\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 Just take a trip in the Black Ball Line\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 Just take a trip to Liverpool\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 To Liverpool, that Yankee school\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 The Yankee sailors you'll see there\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 With red-top boots and short-cut hair\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***
 
 At Liverpool docks we bid adieu\
-_To me way-aye-aye, hurrah-oh_\
+***To me way-aye-aye, hurrah-oh***\
 To friends and loves, but still sing true\
-_Hurrah for the Black Ball Line_
+***Hurrah for the Black Ball Line***

--- a/songs/Blow-The-Man-Down.md
+++ b/songs/Blow-The-Man-Down.md
@@ -21,56 +21,56 @@ _To me way, hey, blow the man down_\
 Now please pay attention and listen to me\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_,\
->_To me way, hey, blow the man down_\
->_Blow him right back to Liverpool town,_\
->_Give me some time to blow the man down_
+> _Blow the man down to me, blow the man down_,\
+> _To me way, hey, blow the man down_\
+> _Blow him right back to Liverpool town,_\
+> _Give me some time to blow the man down_
 
 I'm a deep water sailor just come from Hong Kong,\
 _To me way, hey, blow the man down_\
 You give me some whiskey I'll sing you a song\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 'Twas on a black baller I first served my time,\
 _To me way, hey, blow the man down_\
 On a trim black ball liner I wasted me prime\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 When a trim black ball liner's preparing for sea,\
 _To me way, hey, blow the man down_\
 You'll split your sides laughing, such sights you would see\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 Now when the big liner, she's clear of the land,\
 _To me way, hey, blow the man down_\
 Our bosun he roars out the word of command\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 "Come quickly, lay aft to the break of the poop,\
 _To me way, hey, blow the man down_\
 Or I'll help you along with the toe of my boot"\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 Pay attention to orders now, you one and all,\
 _To me way, hey, blow the man down_\
 For see high above, there flies the Black Ball\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_
 
 'Tis larboard and starboard on deck you will sprawl,\
 _To me way, hey, blow the man down_\
 For Kicking Jack Williams commands the Black Ball\
 _Give me some time to blow the man down_
 
->_Blow the man down to me, blow the man down_
+> _Blow the man down to me, blow the man down_

--- a/songs/Blow-The-Man-Down.md
+++ b/songs/Blow-The-Man-Down.md
@@ -17,60 +17,60 @@ description: >-
   also famed for record-breaking runs.
 ---
 Come all you young fellows that follow the sea,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 Now please pay attention and listen to me\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_,\
-> _To me way, hey, blow the man down_\
-> _Blow him right back to Liverpool town,_\
-> _Give me some time to blow the man down_
+> ***Blow the man down to me, blow the man down,***\
+> ***To me way, hey, blow the man down***\
+> ***Blow him right back to Liverpool town,***\
+> ***Give me some time to blow the man down***
 
 I'm a deep water sailor just come from Hong Kong,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 You give me some whiskey I'll sing you a song\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 'Twas on a black baller I first served my time,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 On a trim black ball liner I wasted me prime\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 When a trim black ball liner's preparing for sea,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 You'll split your sides laughing, such sights you would see\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 Now when the big liner, she's clear of the land,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 Our bosun he roars out the word of command\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 "Come quickly, lay aft to the break of the poop,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 Or I'll help you along with the toe of my boot"\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 Pay attention to orders now, you one and all,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 For see high above, there flies the Black Ball\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***
 
 'Tis larboard and starboard on deck you will sprawl,\
-_To me way, hey, blow the man down_\
+***To me way, hey, blow the man down***\
 For Kicking Jack Williams commands the Black Ball\
-_Give me some time to blow the man down_
+***Give me some time to blow the man down***
 
-> _Blow the man down to me, blow the man down_
+> ***Blow the man down to me, blow the man down***

--- a/songs/Bold-Riley.md
+++ b/songs/Bold-Riley.md
@@ -21,30 +21,30 @@ description: >-
   eventually culminating in her Family Allowances Act of 1945.
 ---
 Our anchor's aweigh and our sails are set,\
-_Bold Riley-oh, bold Riley,_\
+***Bold Riley-oh, bold Riley,***\
 And the folks we're leaving we'll never forget,\
-_Bold Riley-oh has gone away!_
+***Bold Riley-oh has gone away!***
 
-> _Goodbye my sweetheart, goodbye my dear-o,_\
-> _Bold Riley-oh, bold Riley,_\
-> _Goodbye my darling, goodbye my dear-o,_\
-> _Bold Riley-oh has gone away._
+> ***Goodbye my sweetheart, goodbye my dear-o,***\
+> ***Bold Riley-oh, bold Riley,***\
+> ***Goodbye my darling, goodbye my dear-o,***\
+> ***Bold Riley-oh has gone away.***
 
 Wake up Mary Ellen, don't look so glum,\
-_Bold Riley-oh, bold Riley,_\
+***Bold Riley-oh, bold Riley,***\
 On Whitestocking day, you'll be drinking rum\
-_Bold Riley-oh has gone away!_
+***Bold Riley-oh has gone away!***
 
-> _Goodbye my sweetheart, goodbye my dear-o,_
+> ***Goodbye my sweetheart, goodbye my dear-o,***
 
 The rain it rains all day long,\
-_Bold Riley-oh, bold Riley,_\
+***Bold Riley-oh, bold Riley,***\
 And the Northern Gale, it blows so strong,\
-_Bold Riley-oh has gone away!_
+***Bold Riley-oh has gone away!***
 
-> _Goodbye my sweetheart, goodbye my dear-o,_
+> ***Goodbye my sweetheart, goodbye my dear-o,***
 
 So we're outward bound for the Bengal Bay,\
-_Bold Riley-oh, bold Riley,_\
+***Bold Riley-oh, bold Riley,***\
 Bend your backs me boys, it's a hell of a way.\
-_Bold Riley-oh has gone away!_
+***Bold Riley-oh has gone away!***

--- a/songs/Bold-Riley.md
+++ b/songs/Bold-Riley.md
@@ -25,24 +25,24 @@ _Bold Riley-oh, bold Riley,_\
 And the folks we're leaving we'll never forget,\
 _Bold Riley-oh has gone away!_
 
->_Goodbye my sweetheart, goodbye my dear-o,_\
->_Bold Riley-oh, bold Riley,_\
->_Goodbye my darling, goodbye my dear-o,_\
->_Bold Riley-oh has gone away._
+> _Goodbye my sweetheart, goodbye my dear-o,_\
+> _Bold Riley-oh, bold Riley,_\
+> _Goodbye my darling, goodbye my dear-o,_\
+> _Bold Riley-oh has gone away._
 
 Wake up Mary Ellen, don't look so glum,\
 _Bold Riley-oh, bold Riley,_\
 On Whitestocking day, you'll be drinking rum\
 _Bold Riley-oh has gone away!_
 
->_Goodbye my sweetheart, goodbye my dear-o,_
+> _Goodbye my sweetheart, goodbye my dear-o,_
 
 The rain it rains all day long,\
 _Bold Riley-oh, bold Riley,_\
 And the Northern Gale, it blows so strong,\
 _Bold Riley-oh has gone away!_
 
->_Goodbye my sweetheart, goodbye my dear-o,_
+> _Goodbye my sweetheart, goodbye my dear-o,_
 
 So we're outward bound for the Bengal Bay,\
 _Bold Riley-oh, bold Riley,_\

--- a/songs/Bonnie-Ship-the-Diamond.md
+++ b/songs/Bonnie-Ship-the-Diamond.md
@@ -29,10 +29,10 @@ To sail the ocean wide\
 Where the sun it never sets, my lads\
 Nor darkness dims the sky
 
-> _For it's cheer up my lads_\
-> _Let your hearts never fail_\
-> _For the bonnie ship the Diamond_\
-> _Goes a-hunting for the whale_
+> ***For it's cheer up my lads***\
+> ***Let your hearts never fail***\
+> ***For the bonnie ship the Diamond***\
+> ***Goes a-hunting for the whale***
 
 Along the quay at Peterhead\
 The lasses stand around\
@@ -44,7 +44,7 @@ Though you be left behind\
 For the rose will grow on Greenland's ice\
 Before we change our mind
 
-> _For it's cheer up my lads_
+> ***For it's cheer up my lads***
 
 Here's a health to the Resolution\
 Likewise the Eliza Swan\
@@ -56,4 +56,4 @@ The jackets of the blue\
 When we get back to Peterhead\
 We'll have full pockets too
 
-> _For it's cheer up my lads_
+> ***For it's cheer up my lads***

--- a/songs/Boston-Harbour.md
+++ b/songs/Boston-Harbour.md
@@ -15,33 +15,33 @@ When it was blowing a devil of a gale\
 With a ring-tail set all avast the mizzen peak\
 And the Rule Britannia ploughing up the deep
 
-> _With a big bow wow, tow row row_\
-> _Fol dee rol dee rye doh day._
+> ***With a big bow wow, tow row row***\
+> ***Fol dee rol dee rye doh day.***
 
 Then up comes the skipper from down below\
 It's look aloft, and it's look alow\
 And it's look alow and look aloft\
 And it's "coil up your ropes, boys, fore and aft".
 
-> _With a big bow wow, tow row row_
+> ***With a big bow wow, tow row row***
 
 Then down to his cabin he quickly crawls\
 And to his poor old steward bawls\
 "Fix me a drink that will make me cough\
 For it's better weather here than it is on top."
 
-> _With a big bow wow, tow row row_
+> ***With a big bow wow, tow row row***
 
 Now we poor sailors are a-standing on the deck\
 Blasted rain all a-falling down our neck\
 Not a drop of grog could he to us afford\
 But he damns our eyes at every other word.
 
-> _With a big bow wow, tow row row_
+> ***With a big bow wow, tow row row***
 
 Now there's one thing that we have to crave\
 That the captain meets with a watery grave\
 We'll throw him down into some dark hole\
 Where the sharks'll have his body and the Devil have his soul.
 
-> _With a big bow wow, tow row row_
+> ***With a big bow wow, tow row row***

--- a/songs/Boston-Harbour.md
+++ b/songs/Boston-Harbour.md
@@ -15,33 +15,33 @@ When it was blowing a devil of a gale\
 With a ring-tail set all avast the mizzen peak\
 And the Rule Britannia ploughing up the deep
 
->_With a big bow wow, tow row row_\
->_Fol dee rol dee rye doh day._
+> _With a big bow wow, tow row row_\
+> _Fol dee rol dee rye doh day._
 
 Then up comes the skipper from down below\
 It's look aloft, and it's look alow\
 And it's look alow and look aloft\
 And it's "coil up your ropes, boys, fore and aft".
 
->_With a big bow wow, tow row row_
+> _With a big bow wow, tow row row_
 
 Then down to his cabin he quickly crawls\
 And to his poor old steward bawls\
 "Fix me a drink that will make me cough\
 For it's better weather here than it is on top."
 
->_With a big bow wow, tow row row_
+> _With a big bow wow, tow row row_
 
 Now we poor sailors are a-standing on the deck\
 Blasted rain all a-falling down our neck\
 Not a drop of grog could he to us afford\
 But he damns our eyes at every other word.
 
->_With a big bow wow, tow row row_
+> _With a big bow wow, tow row row_
 
 Now there's one thing that we have to crave\
 That the captain meets with a watery grave\
 We'll throw him down into some dark hole\
 Where the sharks'll have his body and the Devil have his soul.
 
->_With a big bow wow, tow row row_
+> _With a big bow wow, tow row row_

--- a/songs/Bully-In-The-Alley.md
+++ b/songs/Bully-In-The-Alley.md
@@ -15,49 +15,49 @@ description: >-
   dilly-dallying, and give Sally more of an active role... which she's used to
   initiate a pre-voyage romp.
 ---
->_So help me Bob, I'm bully in the alley_\
->_Way, hey, bully in the alley_\
->_So help me Bob, I'm bully in the alley_\
->_Bully down in Shinbone Al_
+> _So help me Bob, I'm bully in the alley_\
+> _Way, hey, bully in the alley_\
+> _So help me Bob, I'm bully in the alley_\
+> _Bully down in Shinbone Al_
 
 Sally is the girl that I love dearly\
 _Way, hey, bully in the alley_\
 Sally is the girl that I spliced nearly\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_
 
 I went to tell my Sally dear\
 _Way, hey, bully in the alley_\
 I hoped that she might shed a tear\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_
 
 Sweet Sally only shook her head\
 _Way, hey, bully in the alley_\
 She took my hand, took me to bed\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_
 
 We tossed and tumbled all night long-o\
 _Way, hey, bully in the alley_\
 In the morning the cock did crow-o\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_
 
 I left my Sal, went a-sailing\
 _Way, hey, bully in the alley_\
 Signed on a big ship, went a-whaling\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_
 
 If ever I get back, she says we'll marry\
 _Way, hey, bully in the alley_\
 Have six kids and live in Shinbone Alley\
 _Bully down in Shinbone Al_
 
->_So help me Bob, I'm bully in the alley_
+> _So help me Bob, I'm bully in the alley_

--- a/songs/Bully-In-The-Alley.md
+++ b/songs/Bully-In-The-Alley.md
@@ -15,49 +15,49 @@ description: >-
   dilly-dallying, and give Sally more of an active role... which she's used to
   initiate a pre-voyage romp.
 ---
-> _So help me Bob, I'm bully in the alley_\
-> _Way, hey, bully in the alley_\
-> _So help me Bob, I'm bully in the alley_\
-> _Bully down in Shinbone Al_
+> ***So help me Bob, I'm bully in the alley***\
+> ***Way, hey, bully in the alley***\
+> ***So help me Bob, I'm bully in the alley***\
+> ***Bully down in Shinbone Al***
 
 Sally is the girl that I love dearly\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 Sally is the girl that I spliced nearly\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***
 
 I went to tell my Sally dear\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 I hoped that she might shed a tear\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***
 
 Sweet Sally only shook her head\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 She took my hand, took me to bed\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***
 
 We tossed and tumbled all night long-o\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 In the morning the cock did crow-o\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***
 
 I left my Sal, went a-sailing\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 Signed on a big ship, went a-whaling\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***
 
 If ever I get back, she says we'll marry\
-_Way, hey, bully in the alley_\
+***Way, hey, bully in the alley***\
 Have six kids and live in Shinbone Alley\
-_Bully down in Shinbone Al_
+***Bully down in Shinbone Al***
 
-> _So help me Bob, I'm bully in the alley_
+> ***So help me Bob, I'm bully in the alley***

--- a/songs/Bye-Bye-My-Roseanna.md
+++ b/songs/Bye-Bye-My-Roseanna.md
@@ -11,39 +11,39 @@ tags:
 date: 2019-03-07T08:05:12.000Z
 ---
 The boats are sailing round the bay,\
-_Bye-bye my Roseanna._\
+***Bye-bye my Roseanna.***\
 All loaded down with fishermen,\
-_I won't be home tomorrow._
+***I won't be home tomorrow.***
 
-> _Bye-bye, bye-bye, bye-bye, bye-bye_\
-> _Bye-bye, my Roseanna_\
-> _Bye-bye, bye-bye, bye-bye, bye-bye_\
-> _I won't be home tomorrow_
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***\
+> ***Bye-bye, my Roseanna***\
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***\
+> ***I won't be home tomorrow***
 
 A dollar a day is a fisherman's pay\
-_Bye-bye my Roseanna._\
+***Bye-bye my Roseanna.***\
 It's easy come, easy go away\
-_I won't be home tomorrow._
+***I won't be home tomorrow.***
 
-> _Bye-bye, bye-bye, bye-bye, bye-bye_
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***
 
 We're leaving port at break of day\
-_Bye-bye my Roseanna._\
+***Bye-bye my Roseanna.***\
 We're sailing out across the bay\
-_I won't be home tomorrow._
+***I won't be home tomorrow.***
 
-> _Bye-bye, bye-bye, bye-bye, bye-bye_
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***
 
 Around the horn we must go\
-_Bye-bye my Roseanna._\
+***Bye-bye my Roseanna.***\
 The gales are strong and the winds do blow\
-_I won't be home tomorrow._
+***I won't be home tomorrow.***
 
-> _Bye-bye, bye-bye, bye-bye, bye-bye_
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***
 
 Roseanne, my Roseanne\
-_Bye-bye my Roseanna._\
+***Bye-bye my Roseanna.***\
 I'm going away but not to stay\
-_I won't be home tomorrow._
+***I won't be home tomorrow.***
 
-> _Bye-bye, bye-bye, bye-bye, bye-bye_
+> ***Bye-bye, bye-bye, bye-bye, bye-bye***

--- a/songs/Cape-Cod-Girls.md
+++ b/songs/Cape-Cod-Girls.md
@@ -14,44 +14,44 @@ description: >-
   expense.
 ---
 Cape Cod girls ain't got no combs\
-_Haul away, haul away_\
+***Haul away, haul away***\
 They comb their hair with codfish bones\
-_And we're bound away for Australia_
+***And we're bound away for Australia***
 
-> _So heave away, my bully, bully boys_\
-> _Haul away, haul away_\
-> _Heave away, why don't you make some noise_\
-> _And we're bound away for Australia_
+> ***So heave away, my bully, bully boys***\
+> ***Haul away, haul away***\
+> ***Heave away, why don't you make some noise***\
+> ***And we're bound away for Australia***
 
 Cape Cod kids ain't got no sleds\
-_Haul away, haul away_\
+***Haul away, haul away***\
 They slide down the hills on codfish heads\
-_And we're bound away for Australia_
+***And we're bound away for Australia***
 
-> _So heave away, my bully, bully boys_
+> ***So heave away, my bully, bully boys***
 
 Cape Cod men ain't got no ale\
-_Haul away, haul away_\
+***Haul away, haul away***\
 They fill their glasses with codfish tails\
-_And we're bound away for Australia_
+***And we're bound away for Australia***
 
-> _So heave away, my bully, bully boys_
+> ***So heave away, my bully, bully boys***
 
 Cape Cod folk ain't got no ills\
-_Haul away, haul away_\
+***Haul away, haul away***\
 Cape Cod doctors give 'em codfish pills\
-_And we're bound away for Australia_
+***And we're bound away for Australia***
 
-> _So heave away, my bully, bully boys_
+> ***So heave away, my bully, bully boys***
 
 Cape Cod mothers don't bake no pies\
-_Haul away, haul away_\
+***Haul away, haul away***\
 They feed their kids on codfish eyes\
-_And we're bound away for Australia_
+***And we're bound away for Australia***
 
-> _So heave away, my bully, bully boys_
+> ***So heave away, my bully, bully boys***
 
 Cape Cod cats ain't got no tails\
-_Haul away, haul away_\
+***Haul away, haul away***\
 They got blown off by the northeast gales
-_And we're bound away for Australia_
+***And we're bound away for Australia***

--- a/songs/Essequibo-River.md
+++ b/songs/Essequibo-River.md
@@ -13,44 +13,44 @@ description: >-
 date: 2019-03-07T08:05:12.000Z
 ---
 Essequibo River is the king of rivers all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo River is the king of rivers all\
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_\
-> _Buddy ta-na-na, we are somebody, oh_
+> ***Somebody, oh, Johnny, somebody, oh***\
+> ***Buddy ta-na-na, we are somebody, oh***
 
 Essequibo captain is the king of captains all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo captain is the king of captains all\
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_
+> ***Somebody, oh, Johnny, somebody, oh***
 
 Essequibo sailor is the king of sailors all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo sailor is the king of sailors all\
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_
+> ***Somebody, oh, Johnny, somebody, oh***
 
 Essequibo bosun is the king of bosuns all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo bosun is the king of bosuns all\
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_
+> ***Somebody, oh, Johnny, somebody, oh***
 
 Essequibo whiskey is the king of whiskies all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo whiskey is the king of whiskies all\
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_\
+> ***Somebody, oh, Johnny, somebody, oh***\
 
 Essequibo River is the king of rivers all\
-_Buddy ta-na-na, we are somebody, oh_\
+***Buddy ta-na-na, we are somebody, oh***\
 Essequibo River is the king of rivers all
-_Buddy ta-na-na, we are somebody, oh_
+***Buddy ta-na-na, we are somebody, oh***
 
-> _Somebody, oh, Johnny, somebody, oh_\
+> ***Somebody, oh, Johnny, somebody, oh***\

--- a/songs/Fall-Down-Billy-OShea.md
+++ b/songs/Fall-Down-Billy-OShea.md
@@ -19,60 +19,59 @@ description: >-
   leads to his early demise. The cat referred to is the cat o' nine tails.
 ---
 We all got drunk in Dublin city\
-_Fall down me Billy_\
+***Fall down me Billy***\
 We all got drunk, sure more's the pity\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_\
-> _We're bound away for Americay_\
-> _Fall down Billy O'Shea_
+> ***Fall down, fall down, fall down me Billy***\
+> ***We're bound away for Americay***\
+> ***Fall down Billy O'Shea***
 
 We lay ourselves down on Sir Rogerson's Quay\
-_Fall down me Billy_\
+***Fall down me Billy***\
 And when we woke we were out to sea\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 We are not sailors captain dear\
-_Fall down me Billy_\
+***Fall down me Billy***\
 We come from the land and we won't work here\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 Says the captain, "I've a cure for that"\
-_Fall down me Billy_\
+***Fall down me Billy***\
 "And here for a start is a dose of the cat"\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 Well sent him up to the top-mast yard\
-_Fall down me Billy_\
+***Fall down me Billy***\
 And when he hit the deck, well he took it hard\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 So we wrapped him in the Captain's sail\
-_Fall down me Billy_\
+***Fall down me Billy***\
 And lowered him gently o'er the rail\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 Over the side and down he goes\
-_Fall down me Billy_\
+***Fall down me Billy***\
 Down to Davy Jones with a stitch through his nose\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
+> ***Fall down, fall down, fall down me Billy***
 
 Oh and as he went I heard him say\
-_Fall down me Billy_\
+***Fall down me Billy***\
 I thought we were bound for Americay\
-_Fall down Billy O'Shea_
+***Fall down Billy O'Shea***
 
-> _Fall down, fall down, fall down me Billy_
-
+> ***Fall down, fall down, fall down me Billy***

--- a/songs/Fire-Marengo.md
+++ b/songs/Fire-Marengo.md
@@ -15,31 +15,31 @@ description: >-
   There's no consensus on what 'Marengo' means.
 ---
 Lift him up and carry him along\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 Stow him down where he belongs\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***
 
 Ease him in and let him lay\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 We'll screw him down and there he'll stay\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***
 
 Stow him down in the hold below\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 Screw him down and then we'll go\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***
 
 When I get back to London town\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 I'll pass my line to pretty Sally Brown\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***
 
 Screw the cotton, screw him down\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 Bound away from Hilo Town\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***
 
 Thought I heard the old man say\
-_Fire Marengo, fire away!_\
+***Fire Marengo, fire away!***\
 That's one last turn and then belay\
-_Fire Marengo, fire away!_
+***Fire Marengo, fire away!***

--- a/songs/Go-To-Sea-No-More.md
+++ b/songs/Go-To-Sea-No-More.md
@@ -18,45 +18,45 @@ While money lasts I spent it fast, got drunk as drunk could be\
 And when me money was all gone, 'twas then I wanted more\
 But I'd made up my mind that I was inclined to go to sea no more
 
-_No more, no more, I'll go to sea no more_\
-_I'd made up my mind that I was inclined to go to sea no more_
+***No more, no more, I'll go to sea no more***\
+***I'd made up my mind that I was inclined to go to sea no more***
 
 As I was walking down the street I met with Angeline.\
 She said: “Come home with me, my lad, and we'll have a cracking time.”\
 But when I awoke, it was no joke, I found I was all alone.\
 My silver watch and my money too, and my whole bloody gear was gone.
 
-_Was gone, was gone! My whole bloody gear was gone._\
-_When I awoke, it was no joke for my whole bloody gear was gone._
+***Was gone, was gone! My whole bloody gear was gone.***\
+***When I awoke, it was no joke for my whole bloody gear was gone.***
 
 As I was walking down the street I met big Rapper Brown.\
 I asked him if he would take me in, and he looked at me with a frown.\
 He said, “Last time you was paid off, with me you chalked up no score,\
 But I'll take your advance and I'll give youse a chance to go to sea once more.”
 
-_"Once more, once more! To go to sea once more._\
-_I'll take your advance and I'll give youse a chance to go to sea once more.”_
+***"Once more, once more! To go to sea once more.***\
+***I'll take your advance and I'll give youse a chance to go to sea once more.”***
 
 He shipped me on board of a whaling ship bound for the Arctic seas,\
 Where cold winds blow and there's frost and snow and Jamaica rum would freeze.\
 And worse to bear, I'd no hard-weather gear, for I'd lost all my dunnage ashore.\
 It was then that I wished that I was dead so I'd go to sea no more.
 
-_No more, no more! I'd go to sea no more._\
-_It was then that I wished that I was dead so I'd go to sea no more._
+***No more, no more! I'd go to sea no more.***\
+***It was then that I wished that I was dead so I'd go to sea no more.***
 
 Sometimes we're catching whales, my lads, but mostly we get none,\
 With a twenty-foot oar in every paw from five o'clock in the morn.\
 And when daylight's gone and the night coming on, you rest upon your oar,\
 And oh boys, you wish that you was dead or snug with the girls ashore.
 
-_Ashore, ashore! Snug with the girls ashore._\
-_Oh boys, you wish that you was dead or snug with the girls ashore._
+***Ashore, ashore! Snug with the girls ashore.***\
+***Oh boys, you wish that you was dead or snug with the girls ashore.***
 
 Come all you bold seafaring lads that listen to my song.\
 Now it's when you come off them long trips, I'll have you not go wrong.\
 Take my advice, drink no strong drink, but lay up your money in store,\
 Get married my boys and spend all night in bed and go to sea no more.
 
-_No more, no more! Don't go to sea no more._\
-_Get married my boys and spend all night in bed and go to sea no more._
+***No more, no more! Don't go to sea no more.***\
+***Get married my boys and spend all night in bed and go to sea no more.***

--- a/songs/Greenland-Whale-Fishery.md
+++ b/songs/Greenland-Whale-Fishery.md
@@ -12,35 +12,35 @@ date: 2019-03-07T08:05:12.000Z
 In eighteen hundred and forty-six\
 And of March the eighteenth day,\
 We hoisted our colours to the top of the mast\
-_And for Greenland sailed away, brave boys,_\
-_And for Greenland sailed away._
+***And for Greenland sailed away, brave boys,***\
+***And for Greenland sailed away.***
 
 The lookout in the crosstrees stood\
 With spyglass in his hand;\
 There's a whale, there's a whale, and a whalefish he cried\
-_And she blows at every span, brave boys_\
-_And she blows at every span._
+***And she blows at every span, brave boys***\
+***And she blows at every span.***
 
 The captain stood on the quarter deck,\
 The ice was in his eye;\
 Overhaul, overhaul! let your gibsheets fall,\
-_And you'll put your boats to sea, brave boys_\
-_And you'll put your boats to sea._
+***And you'll put your boats to sea, brave boys***\
+***And you'll put your boats to sea.***
 
 Our harpoon struck and the line played out,\
 With a single flourish of his tail,\
 He capsized the boat and we lost five men,\
-_And we did not catch the whale, brave boys,_\
-_And we did not catch the whale._
+***And we did not catch the whale, brave boys,***\
+***And we did not catch the whale.***
 
 The losing of those five jolly men,\
 It grieved the captain sore,\
 But the losing of that fine whalefish\
-_Now it grieved him ten times more, brave boys_\
-_Now it grieved him ten times more._
+***Now it grieved him ten times more, brave boys***\
+***Now it grieved him ten times more.***
 
 Oh Greenland is a barren land\
 A land that bears no green\
 Where there's ice and snow, and the whalefishes blow\
-_And the daylight's seldom seen, brave boys_\
-_And the daylight's seldom seen._
+***And the daylight's seldom seen, brave boys***\
+***And the daylight's seldom seen.***

--- a/songs/Grey-Funnel-Line.md
+++ b/songs/Grey-Funnel-Line.md
@@ -23,34 +23,34 @@ Don't mind the rain or the rolling sea\
 The weary night never worries me\
 But the hardest time in a sailor's day\
 Is to watch the sun as it dies away\
-_And it's one more day on the Grey Funnel Line_
+***And it's one more day on the Grey Funnel Line***
 
 The finest ship that sails the sea\
 Is still a prison for the likes of me\
 But give me wings like Noah's dove\
 I'll fly up harbour to the girl I love\
-_And it's one more day on the Grey Funnel Line_
+***And it's one more day on the Grey Funnel Line***
 
 There was a time my heart was free\
 Like a floating spar on the open sea\
 But now the spar is washed ashore\
 It comes to rest at my real love's door\
-_It's one more day on the Grey Funnel Line_
+***It's one more day on the Grey Funnel Line***
 
 Every time I gaze behind the screws\
 Makes me long for old Peter's shoes\
 I'd walk right down that silver lane\
 And take my love in my arms again\
-_It's one more day on the Grey Funnel Line_
+***It's one more day on the Grey Funnel Line***
 
 Oh Lord if dreams were only real\
 I'd feel my hands on that wooden wheel\
 And with all my heart I'd turn her round\
 And tell the boys that we're homeward bound\
-_And it's one more day on the Grey Funnel Line_
+***And it's one more day on the Grey Funnel Line***
 
 I'll pass the time like some machine\
 Until the waters turn to green\
 Then I'll dance on down that walk ashore\
-_And sail the Grey Funnel Line no more_\
-_And sail the Grey Funnel Line no more_
+***And sail the Grey Funnel Line no more***\
+***And sail the Grey Funnel Line no more***

--- a/songs/Hanging-Johnny.md
+++ b/songs/Hanging-Johnny.md
@@ -20,11 +20,11 @@ description: >-
 ---
 They call me hanging Johnny,
 
-> _Away, boys, away!_
+> ***Away, boys, away!***
 
 They say I hang for money!
 
-> _So hang, boys, hang down!_
+> ***So hang, boys, hang down!***
 
 They say I hanged my mother,\
 My sisters and my brothers

--- a/songs/Haul-Away-Joe.md
+++ b/songs/Haul-Away-Joe.md
@@ -18,22 +18,22 @@ description: >-
 Louis was the king of France\
 Before the revolut-i-on
 
-_Away, haul away, we'll haul away Joe_
+***Away, haul away, we'll haul away Joe***
 
 But then he got his head chopped off\
 Which spoiled his constitut-i-on
 
-_Away, haul away, we'll haul away Joe_
+***Away, haul away, we'll haul away Joe***
 
-> _(To me) way, haul away_
-> _(To me) way, haul away_
-> _We'll haul away together_
-> _(To me) way, haul away_
-> _We'll haul away together_
-> _Away, haul away, we'll haul away Joe_
-> _(To me) way, haul away_
-> _We'll haul for better weather_
-> _Away, haul away, we'll haul away Joe_
+> ***(To me) way, haul away***\
+> ***(To me) way, haul away***\
+> ***We'll haul away together***\
+> ***(To me) way, haul away***\
+> ***We'll haul away together***\
+> ***Away, haul away, we'll haul away Joe***\
+> ***(To me) way, haul away***\
+> ***We'll haul for better weather***\
+> ***Away, haul away, we'll haul away Joe***
 
 Saint Patrick was a gentleman\
 He came from decent people\

--- a/songs/High-Barbary.md
+++ b/songs/High-Barbary.md
@@ -17,9 +17,9 @@ description: >-
   celebrates a victory of two English shops over one of the Barbary pirates.
 ---
 There were two lofty ships from old England came\
-_Blow high, blow low and so sail we_\
+***Blow high, blow low and so sail we***\
 One was the Prince of Luther, the other Prince of Wales\
-_All a-cruisin' down the coast of High Barbary_ 
+***All a-cruisin' down the coast of High Barbary*** 
 
 Aloft there, aloft there our jolly bosun cried\
 Look ahead, look astern, look to weather an' a-lee\

--- a/songs/John-B-Sails.md
+++ b/songs/John-B-Sails.md
@@ -20,12 +20,12 @@ Drinkin' all night\
 Got into a fight\
 Well, I feel so broke up and I want to go home
 
-> _Hoist up the John B's sails_
-> _See how the main sails set_
-> _Call for the captain ashore, let me go home_
-> _Let me go home_
-> _I want to go home_
-> _Well, I feel so broke up, I want to go home_
+> ***Hoist up the John B's sails***\
+> ***See how the main sails set***\
+> ***Call for the captain ashore, let me go home***\
+> ***Let me go home***\
+> ***I want to go home***\
+> ***Well, I feel so broke up, I want to go home***
 
 First mate, he got drunk\
 Broke up the people's trunk\

--- a/songs/John-the-slacker.md
+++ b/songs/John-the-slacker.md
@@ -29,14 +29,14 @@ description: >-
 ---
 I thought I heard the old man say
 
-_John, the slacker, slacker, too lie ay_
+***John, the slacker, slacker, too lie ay***
 
 Today, today is a holiday
 
-_John, the slacker, slacker, too lie ay_
+***John, the slacker, slacker, too lie ay***
 
-> _Too lie ay, oh, to lie ay (hoo)_
-> _John, the slacker, slacker, too lie ay_
+> ***Too lie ay, oh, to lie ay (hoo)***\
+> ***John, the slacker, slacker, too lie ay***
 
 We'll work tomorrow but no work today\
 We'll work tomorrow but no work today

--- a/songs/Last-Shanty.md
+++ b/songs/Last-Shanty.md
@@ -15,10 +15,10 @@ A sailor's life was very hard, the food was always bad\
 But now I've joined the navy, I'm aboard a man-o-war\
 And now I've found a sailor ain't a sailor any more
 
-> _Don't haul on the rope, don't climb up the mast_
-> _If you see a sailing ship it might be your last_
-> _Just get your civies ready for another run ashore_
-> _A sailor ain't a sailor, ain't a sailor anymore_
+> ***Don't haul on the rope, don't climb up the mast***\
+> ***If you see a sailing ship it might be your last***\
+> ***Just get your civies ready for another run ashore***\
+> ***A sailor ain't a sailor, ain't a sailor anymore***
 
 Well the killock of our mess he says we've had it soft\
 It wasn't like this in his day when he was up aloft\

--- a/songs/Leave-her-Johnny.md
+++ b/songs/Leave-her-Johnny.md
@@ -22,20 +22,20 @@ description: >-
   sailing down the river to approach the pier head the shanty singer would let
   rip with this song, finally airing months of pent up frustrations.  As such,
   every time this song was sung would have been different to match the specific
-  anger of the ship. The verses listed below are _not_ a command, and if you
+  anger of the ship. The verses listed below are ***not*** a command, and if you
   sang them all you'd be here a very long while. Rather, pick and choose your
   favourites. Or better still, write some yourself about whatever's grinding
   your gears - the patriarchy, the government, rival pubs, viola players etc.
 ---
 I thought I heard the Old Man say\
-_Leave her, Johnny, leave her_\
+***Leave her, Johnny, leave her***\
 You can go ashore and take your pay\
-_And it's time for us to leave her_\
+***And it's time for us to leave her***\
 \
-_Leave her, Johnny, leave her_\
-_Oh, leave her, Johnny, leave her_\
-_For the voyage was long and the winds did blow_\
-_And it's time for us to leave her_\
+***Leave her, Johnny, leave her***\
+***Oh, leave her, Johnny, leave her***\
+***For the voyage was long and the winds did blow***\
+***And it's time for us to leave her***\
 \
 Oh her stern was foul and the voyage was long\
 The winds was bad and the gales was strong

--- a/songs/Lowlands.md
+++ b/songs/Lowlands.md
@@ -19,11 +19,11 @@ description: >-
 
 I dreamed a dream the other night
 
-> _Lowlands, lowlands away my John_
+> ***Lowlands, lowlands away my John***
 
 I dreamed a dream the other night
 
-> _Lowlands away_
+> ***Lowlands away***
 
 I dreamed my love came in my sleep\
 Her cheeks were wet, her eyes did weep
@@ -44,11 +44,11 @@ Then awoke to hear the cry\
 
 I dreamed a dream the other night
 
-> _Lowlands, lowlands away my John_
+> ***Lowlands, lowlands away my John***
 
 I dreamed a dream the other night
 
-> _Lowlands away_
+> ***Lowlands away***
 
 I dreamed I saw my own true love\
 He stood so still, he did not move

--- a/songs/Mary-Ellen-Carter.md
+++ b/songs/Mary-Ellen-Carter.md
@@ -66,10 +66,10 @@ She's worth a quarter million afloatin' at the dock\
 And with every jar that hit the bar we swore we would remain\
 And make the Mary Ellen Carter rise again
 
-> _Rise again, rise again!_\
-> _May her name not be lost to the knowledge of men_\
-> _All those who loved her best and who were with her till the end_\
-> _Will make the Mary Ellen Carter rise again!_
+> ***Rise again, rise again!***\
+> ***May her name not be lost to the knowledge of men***\
+> ***All those who loved her best and who were with her till the end***\
+> ***Will make the Mary Ellen Carter rise again!***
 
 All spring now we've been with her on a barge lent by a friend\
 Three dives a day in a hard hat suit and twice I've had the bends\
@@ -81,10 +81,10 @@ Put cables to her fore and aft and girded her around\
 Tomorrow noon we'll hit the air and then take up the strain\
 And make the Mary Ellen Carter rise again
 
-> _Rise again, rise again!_\
-> _May her name not be lost to the knowledge of men_\
-> _All those who loved her best and who were with her till the end_\
-> _Will make the Mary Ellen Carter rise again!_
+> ***Rise again, rise again!***\
+> ***May her name not be lost to the knowledge of men***\
+> ***All those who loved her best and who were with her till the end***\
+> ***Will make the Mary Ellen Carter rise again!***
 
 Well, we couldn't leave her there, you see, to crumble into scale\
 She'd saved our lives so many times fightin' through the gale\
@@ -95,11 +95,11 @@ We're smiling bastards lying to you everywhere you go\
 Turn to and put out all your strength of arm and heart and brain\
 And like the Mary Ellen Carter, rise again
 
-> _Rise again, rise again!_\
-> _Though your heart it be broke and your life about to end_\
-> _No matter what you lost, be it a home, a love, a friend_\
-> _Like the Mary Ellen Carter, rise again!_\
-> _Rise again, rise again!_\
-> _Though your heart it be broke and your life about to end_\
-> _No matter what you lost, be it a home, a love, a friend_\
-> _Like the Mary Ellen Carter, rise again!_
+> ***Rise again, rise again!***\
+> ***Though your heart it be broke and your life about to end***\
+> ***No matter what you lost, be it a home, a love, a friend***\
+> ***Like the Mary Ellen Carter, rise again!***\
+> ***Rise again, rise again!***\
+> ***Though your heart it be broke and your life about to end***\
+> ***No matter what you lost, be it a home, a love, a friend***\
+> ***Like the Mary Ellen Carter, rise again!***

--- a/songs/Mermaid.md
+++ b/songs/Mermaid.md
@@ -15,11 +15,11 @@ And we were not far from the land\
 When our captain, he spied a fishy mermaid\
 With a comb and a glass in her hand
 
-> _Oh the ocean waves do roll_
-> _And the stormy winds do blow_
-> _And we poor sailors are skipping at the top_
-> _While the landlubbers lie down below, below, below_
-> _While the landlubbers lie down below_
+> ***Oh the ocean waves do roll***\
+> ***And the stormy winds do blow***\
+> ***And we poor sailors are skipping at the top***\
+> ***While the landlubbers lie down below, below, below***\
+> ***While the landlubbers lie down below***
 
 Now the song she sang, she sang so sweet,\
 No answer at all could I say\

--- a/songs/Mollymauk.md
+++ b/songs/Mollymauk.md
@@ -18,56 +18,56 @@ description: >-
 ---
 Oh the southern ocean is a lonely place\
 Where the storms are many and the shelter's scarce\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
 On the restless water and the troublin' skies\
 You can see that mollymauk wheel and fly\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***
 
-_Won't you ride the wind and go, white seabird_\
-_Ride the wind and go, Mollymauk_\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Won't you ride the wind and go, white seabird***\
+***Ride the wind and go, Mollymauk***\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***
 
 See the Mollymauk floatin' on her wide white wings\
 And Lord, what a lonely song she sings\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
 And she's got no compass and she's got no gear\
 And there's none can tell you how the Mollymauks steer\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***
 
-_Won't you ride the wind and go, white seabird_\
-_Ride the wind and go, Mollymauk_\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
+***Won't you ride the wind and go, white seabird***\
+***Ride the wind and go, Mollymauk***\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
 \
 She's the ghost of a sailor-woman I've heard say\
 Whose body sank, and her soul flew away\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
 And she's got no haven and she's got no home\
 She's bound evermore for to wheel and roam\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***
 
-_Won't you ride the wind and go, white seabird_\
-_Ride the wind and go, Mollymauk_\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
-__\
-_When I gets too weary for to sail no more_\
-_Let my bones sink better far away from shore_\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_\
+***Won't you ride the wind and go, white seabird***\
+***Ride the wind and go, Mollymauk***\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
+******\
+***When I gets too weary for to sail no more***\
+***Let my bones sink better far away from shore***\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***\
 You can cast me loose and leave me driftin' free\
 And I'll keep that big bird company\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***
 
-_Won't you ride the wind and go, white seabird_\
-_Ride the wind and go, Mollymauk_\
-_Down upon the southern ocean sailing_\
-_Down below Cape Horn_
+***Won't you ride the wind and go, white seabird***\
+***Ride the wind and go, Mollymauk***\
+***Down upon the southern ocean sailing***\
+***Down below Cape Horn***

--- a/songs/Noahs-Ark-Shanty.md
+++ b/songs/Noahs-Ark-Shanty.md
@@ -11,14 +11,14 @@ tags:
   - song
 ---
 In Frisco Bay there were three ships,\
-_To me way, hey, hey, oh._\
+***To me way, hey, hey, oh.***\
 In Frisco Bay there were three ships,\
-_A long time ago._
+***A long time ago.***
 
 And one of those ships was Noah's old ark,\
-_To me way, hey, hey, oh._\
+***To me way, hey, hey, oh.***\
 Covered all over with hickory bark.\
-_A long time ago._
+***A long time ago.***
 
 They took two animals of every kind,\
 They took two animals of every kind.

--- a/songs/Old-Maui.md
+++ b/songs/Old-Maui.md
@@ -32,10 +32,10 @@ With a good ship, taut and free
 And we don't give a damn when we drink our rum
 With the girls of old Maui
 
-_Rolling down to old Maui, me boys_\
-_Rolling down to old Maui_\
-_We're homeward bound from the Artic ground_\
-_Rolling down to old Maui_
+***Rolling down to old Maui, me boys***\
+***Rolling down to old Maui***\
+***We're homeward bound from the Artic ground***\
+***Rolling down to old Maui***
 
 Once more we sail with a northerly gale\
 Towards our island home.\

--- a/songs/One-More-Day.md
+++ b/songs/One-More-Day.md
@@ -12,9 +12,9 @@ date: 2019-03-07T08:05:12.000Z
 description: Another shanty that usually needs some judicious verse-trimming.
 ---
 Have you heard the news, my Johnny\
-_One more day!_\
+***One more day!***\
 We're homeward bound tomorrow\
-_Only one more day!_
+***Only one more day!***
 
 Don't you hear the old man growlin'\
 Don't you hear the mate a howlin'

--- a/songs/Pay-Me-My-Money-Down.md
+++ b/songs/Pay-Me-My-Money-Down.md
@@ -11,14 +11,14 @@ tags:
 date: 2019-03-07T08:05:12.000Z
 ---
 I thought I heard our captain say\
-_Pay me my money down_\
+***Pay me my money down***\
 Tomorrow is our sailing day\
-_Pay me my money down_
+***Pay me my money down***
 
-_Pay me, Oh pay me_\
-_Pay me my money down_\
-_Pay me or go to jail_\
-_Pay me my money down_
+***Pay me, Oh pay me***\
+***Pay me my money down***\
+***Pay me or go to jail***\
+***Pay me my money down***
 
 Soon as the boat was clear of the bar\
 He knocked me down with the end of a spar

--- a/songs/Poor-Old-Horse.md
+++ b/songs/Poor-Old-Horse.md
@@ -12,11 +12,11 @@ date: 2019-03-07T08:05:12.000Z
 ---
 They say, old man, your horse will die
 
-> And they say so, and we hope so
+> ***And they say so, and we hope so***
 
 They say, old man, your horse will die
 
-> Oh poor old man
+> ***Oh poor old man***
 
 And if he dies then we'll tan his hide
 

--- a/songs/Rio-Grande.md
+++ b/songs/Rio-Grande.md
@@ -11,14 +11,14 @@ tags:
 date: 2019-03-07T08:05:12.000Z
 ---
 Our ship is a-sailing out over the Bar\
-_'way down Rio_\
+***'way down Rio***\
 We're pointing her bow to the Southern Star\
-_And we're bound for the Rio Grande_
+***And we're bound for the Rio Grande***
 
-_Then away, boys, away_\
-_'way down Rio_\
-_So fare thee well, my Bonny young girl_\
-_We're bound for the Rio Grande_
+***Then away, boys, away***\
+***'way down Rio***\
+***So fare thee well, my Bonny young girl***\
+***We're bound for the Rio Grande***
 
 Say was you ever down Rio Grande?\
 It's there that the river flows down golden sand!

--- a/songs/Roll-Alabama,-Roll.md
+++ b/songs/Roll-Alabama,-Roll.md
@@ -20,11 +20,11 @@ description: >-
 ---
 When the Alabama's keel was laid
 
-> Roll, Alabama, roll
+> ***Roll, Alabama, roll***
 
 It was laid in the yards of Jonathan Laird
 
-> Oh roll, Alabama, roll
+> ***Oh roll, Alabama, roll***
 
 It was laid in the yards of Jonathan Laird\
 It was laid in the town of Birkenhead

--- a/songs/Roll-Down.md
+++ b/songs/Roll-Down.md
@@ -11,18 +11,18 @@ tags:
 date: 2019-03-07T08:05:12.000Z
 ---
 Sweet ladies of Plymouth, we're saying goodbye\
-_Ro-o-o-oll down!_\
+***Ro-o-o-oll down!***\
 But we'll rock you and roll you again bye and bye\
-_Walk her round, me brave boys and roll down!_\
-_And we will ro-o-o-oll down!_\
-_Walk her round, me brave boys and roll down!_
+***Walk her round, me brave boys and roll down!***\
+***And we will ro-o-o-oll down!***\
+***Walk her round, me brave boys and roll down!***
 
 Now the anchor's aweigh and the sails are unfurled\
-_Ro-o-o-oll down!_\
+***Ro-o-o-oll down!***\
 And we're bound for to take her half-way round the world\
-_Walk her round, me brave boys and roll down!_\
-_And we will ro-o-o-oll down!_\
-_Walk her round, me brave boys and roll down!_
+***Walk her round, me brave boys and roll down!***\
+***And we will ro-o-o-oll down!***\
+***Walk her round, me brave boys and roll down!***
 
 In the wide Bay of Biscay the seas will run high\
 And the poor sickly transports they'll wish they could die

--- a/songs/Roll-The-Old-Chariot-Along.md
+++ b/songs/Roll-The-Old-Chariot-Along.md
@@ -14,10 +14,10 @@ Oh we'd be all right, if the wind was in our sails (x3)
 
 _And we'll all hang on behind_
 
->_And we'll roll the old chariot along_
->_We'll roll the old chariot along_
->_And we'll roll the old chariot along_
->_And we'll all hang on behind_
+> _And we'll roll the old chariot along_
+> _We'll roll the old chariot along_
+> _And we'll roll the old chariot along_
+> _And we'll all hang on behind_
 
 Well a drop of Nelson's blood wouldn't do us any harm (x3)
 

--- a/songs/Roll-The-Old-Chariot-Along.md
+++ b/songs/Roll-The-Old-Chariot-Along.md
@@ -12,12 +12,12 @@ date: 2019-03-07T08:05:12.000Z
 ---
 Oh we'd be all right, if the wind was in our sails (x3)
 
-_And we'll all hang on behind_
+***And we'll all hang on behind***
 
-> _And we'll roll the old chariot along_
-> _We'll roll the old chariot along_
-> _And we'll roll the old chariot along_
-> _And we'll all hang on behind_
+> ***And we'll roll the old chariot along***\
+> ***We'll roll the old chariot along***\
+> ***And we'll roll the old chariot along***\
+> ***And we'll all hang on behind***
 
 Well a drop of Nelson's blood wouldn't do us any harm (x3)
 

--- a/songs/Rollickin-Randy-Dandy-O.md
+++ b/songs/Rollickin-Randy-Dandy-O.md
@@ -12,14 +12,14 @@ description:
 date: 2019-03-07T08:05:12.000Z
 ---
 Now we are ready to head for the horn,\
-_Weigh, hey, roll an' go!_\
+***Weigh, hey, roll an' go!***\
 Our boots an' our clothes boys are all in the pawn,\
-_To me rollickin' Randy Dandy O!_
+***To me rollickin' Randy Dandy O!***
 
 Heave a pawl, oh, heave away,\
-_Weigh, hey, roll and go!_\
+***Weigh, hey, roll and go!***\
 The anchor's on board an' the cable's all stored,\
-_To me rollickin' Randy Dandy O!_
+***To me rollickin' Randy Dandy O!***
 
 Man the stout caps'n and heave with a will,\
 For soon we'll be drivin' her 'way up the hill.

--- a/songs/Running-Down-To-Cuba.md
+++ b/songs/Running-Down-To-Cuba.md
@@ -11,20 +11,20 @@ tags:
 date: 2019-03-07T08:05:12.000Z
 ---
 To Cuba's coast we're bound me boys\
-_Way, me boys, for Cuba_\
+***Way, me boys, for Cuba***\
 To Cuba's coast boys, don't you make a noise\
-_Running down to Cuba._
+***Running down to Cuba.***
 
-> _Way, me boys, for Cuba_
-> _Running down to Cuba_
+> ***Way, me boys, for Cuba***\
+> ***Running down to Cuba***
 
 The Captain he will trim the sails\
-_Way, me boys, for Cuba_\
+***Way, me boys, for Cuba***\
 Flinging the water out over the rails\
-_Running down to Cuba._
+***Running down to Cuba.***
 
-_Way, me boys, for Cuba_\
-_Running down to Cuba_
+***Way, me boys, for Cuba***\
+***Running down to Cuba***
 
 Oh my lord! how the wind do blow
 Running South from the ice and snow

--- a/songs/Sams-Gone-Away.md
+++ b/songs/Sams-Gone-Away.md
@@ -6,23 +6,27 @@ chorusLine: 'Sam’s gone away, aboard a Man O’War'
 songLine: 'I wish I was a cabin boy, aboard a Man O’War'
 date: 2019-03-07T08:05:12.000Z
 ---
-I wish I was a cabin boy, aboard a Man O\'War
+I wish I was a cabin boy, aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-> Sam\'s gone away, aboard a Man O\'War
+I wish I was a cabin boy, aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-I wish I was a cabin boy, aboard a Man O\'War
+> ***Pretty work, brave boys***\
+> ***Pretty work, I say***\
+> ***Sam\'s gone away, aboard a Man O\'War***
 
-> Sam\'s gone away, aboard a Man O\'War
-Pretty work, brave boys
-Pretty work, I say
-Sam\'s gone away, aboard a Man O\'War
+I wish I was the Bosun aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-I wish I was the Bosun aboard a Man O\'War
+I wish I was the Midshipman aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-I wish I was the Midshipman aboard a Man O\'War
+I wish I was the Captain, aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-I wish I was the Captain, aboard a Man O\'War
+I wish I was the Admiral aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***
 
-I wish I was the Admiral aboard a Man O\'War
-
-I wish I was a sailor lass aboard a Man O\'War
+I wish I was a sailor lass aboard a Man O\'War\
+***Sam\'s gone away, aboard a Man O\'War***

--- a/songs/Sams-Gone-Away.md
+++ b/songs/Sams-Gone-Away.md
@@ -8,11 +8,11 @@ date: 2019-03-07T08:05:12.000Z
 ---
 I wish I was a cabin boy, aboard a Man O\'War
 
->Sam\'s gone away, aboard a Man O\'War
+> Sam\'s gone away, aboard a Man O\'War
 
 I wish I was a cabin boy, aboard a Man O\'War
 
->Sam\'s gone away, aboard a Man O\'War
+> Sam\'s gone away, aboard a Man O\'War
 Pretty work, brave boys
 Pretty work, I say
 Sam\'s gone away, aboard a Man O\'War

--- a/songs/Shenandoah.md
+++ b/songs/Shenandoah.md
@@ -13,22 +13,22 @@ description: >-
   traveling down the Missouri River in canoes in the early 19th Century.
 ---
 Oh Shenandoah, I long to see you,\
-_Away you rolling river._\
+***Away you rolling river.***\
 Oh Shenandoah, I long to see you\
-_Away, I'm bound away_\
-_Across The wide Missouri._
+***Away, I'm bound away***\
+***Across The wide Missouri.***
 
 Oh Shenandoah, I love your Daughter,\
-_Away you rolling river._\
+***Away you rolling river.***\
 For her I'd cross your roaming waters,\
-_Away, I'm bound away_\
-_Across The wide Missouri._\
-__\
+***Away, I'm bound away***\
+***Across The wide Missouri.***
+
 'Tis seven years since last I've seen you,\
-_Away you rolling river._\
+***Away you rolling river.***\
 'Tis seven years since last I've seen you,\
-_Away, I'm bound away_\
-_Across The wide Missouri._
+***Away, I'm bound away***\
+***Across The wide Missouri.***
 
 Oh Shenandoah, I long to hear you,\
 Oh Shenandoah, I long to hear you,

--- a/songs/South-Australia.md
+++ b/songs/South-Australia.md
@@ -11,19 +11,19 @@ date: 2019-03-07T08:05:12.000Z
 ---
 In South Australia I was born
 
-> (To me) heave away, haul away
+> ***(To me) heave away, haul away***
 
 In South Australia round Cape Horn
 
-> We're bound for South Australia
+> ***We're bound for South Australia***
 
 Haul away you rolling Kings
 
-> (To me) heave away, haul away
+> ***(To me) heave away, haul away***
 
 Haul away, you'll hear me sing
 
-> We're bound for South Australia
+> ***We're bound for South Australia***
 
 As I walked out one morning fair
 

--- a/songs/South-Australia.md
+++ b/songs/South-Australia.md
@@ -11,19 +11,19 @@ date: 2019-03-07T08:05:12.000Z
 ---
 In South Australia I was born
 
->(To me) heave away, haul away
+> (To me) heave away, haul away
 
 In South Australia round Cape Horn
 
->We're bound for South Australia
+> We're bound for South Australia
 
 Haul away you rolling Kings
 
->(To me) heave away, haul away
+> (To me) heave away, haul away
 
 Haul away, you'll hear me sing
 
->We're bound for South Australia
+> We're bound for South Australia
 
 As I walked out one morning fair
 

--- a/songs/Spanish-Ladies.md
+++ b/songs/Spanish-Ladies.md
@@ -16,7 +16,7 @@ Farewell and adieu to you ladies of Spain\
 For we've received orders to sail for old England\
 But we hope in a short while to see you again
 
->We'll rant and we'll roar like true British sailors\
+> We'll rant and we'll roar like true British sailors\
 We'll rant and we'll roar across the salt seas\
 Until we strike soundings in the channel of Old England\
 From Ushant to Scilly is thirty-five leagues
@@ -26,7 +26,7 @@ We hove our ship to, our soundings to take\
 So we rounded and sounded; got forty-five fathoms\
 We squared our main yard and up channel did make
 
->We'll rant and we'll roar like true British sailors\
+> We'll rant and we'll roar like true British sailors\
 We'll rant and we'll roar across the salt seas\
 Until we strike soundings in the channel of Old England\
 From Ushant to Scilly is thirty-five leagues
@@ -36,18 +36,18 @@ Next Ram's Head off Plymouth, off Portland the Wight\
 We sailed by Beachy, by Fairlee and Dungeness\
 Till we came abreast of the South Foreland Light
 
->We'll rant and we'll roar like true British sailors...
+> We'll rant and we'll roar like true British sailors...
 
 Then the order was made for the Grand Fleet to anchor\
 All in the downs that night for to lie\
 Let go your shank-painters, let go your cat-stoppers,\
 Haul up your clew garnets, let tacks and sheets fly
 
->We'll rant and we'll roar like true British sailors...
+> We'll rant and we'll roar like true British sailors...
 
 Now let every one toss off a full bumper\
 And let every one drink off a full glass\
 And we'll drink and be jolly and drown melancholy\
 Singing, here's to the health to each true-hearted lass
 
->We'll rant and we'll roar like true British sailors...
+> We'll rant and we'll roar like true British sailors...

--- a/songs/Spanish-Ladies.md
+++ b/songs/Spanish-Ladies.md
@@ -16,7 +16,7 @@ Farewell and adieu to you ladies of Spain\
 For we've received orders to sail for old England\
 But we hope in a short while to see you again
 
-> We'll rant and we'll roar like true British sailors\
+> ***We'll rant and we'll roar like true British sailors***\
 We'll rant and we'll roar across the salt seas\
 Until we strike soundings in the channel of Old England\
 From Ushant to Scilly is thirty-five leagues
@@ -26,7 +26,7 @@ We hove our ship to, our soundings to take\
 So we rounded and sounded; got forty-five fathoms\
 We squared our main yard and up channel did make
 
-> We'll rant and we'll roar like true British sailors\
+> ***We'll rant and we'll roar like true British sailors***\
 We'll rant and we'll roar across the salt seas\
 Until we strike soundings in the channel of Old England\
 From Ushant to Scilly is thirty-five leagues
@@ -36,18 +36,18 @@ Next Ram's Head off Plymouth, off Portland the Wight\
 We sailed by Beachy, by Fairlee and Dungeness\
 Till we came abreast of the South Foreland Light
 
-> We'll rant and we'll roar like true British sailors...
+> ***We'll rant and we'll roar like true British sailors...***
 
 Then the order was made for the Grand Fleet to anchor\
 All in the downs that night for to lie\
 Let go your shank-painters, let go your cat-stoppers,\
 Haul up your clew garnets, let tacks and sheets fly
 
-> We'll rant and we'll roar like true British sailors...
+> ***We'll rant and we'll roar like true British sailors...***
 
 Now let every one toss off a full bumper\
 And let every one drink off a full glass\
 And we'll drink and be jolly and drown melancholy\
 Singing, here's to the health to each true-hearted lass
 
-> We'll rant and we'll roar like true British sailors...
+> ***We'll rant and we'll roar like true British sailors...***

--- a/songs/Stormalong-John.md
+++ b/songs/Stormalong-John.md
@@ -12,11 +12,11 @@ date: 2019-03-07T08:05:12.000Z
 ---
 Stormy's gone that good old man
 
-_Way, stormalong, John!_
+***Way, stormalong, John!***
 
 O, poor old Stormy's dead and gone,
 
-_Way hay, mister. Stormalong John!_
+***Way hay, mister. Stormalong John!***
 
 We dug his grave with a silver spade,\
 His shroud of the finest silk was made.

--- a/songs/Strike-The-Bell.md
+++ b/songs/Strike-The-Bell.md
@@ -19,14 +19,14 @@ He only knows himself\
 Oh, we wish that he would hurry up\
 And strike, strike the bell
 
-_Strike the bell, Second Mate_\
-_Let us go below_\
-_Look away to windward_\
-_You can see it's going to blow_\
-_Look at the glass_\
-_You can see that it is fell_\
-_We wish the you would hurry up_\
-_And strike, strike the bell_
+> ***Strike the bell, Second Mate***\
+> ***Let us go below***\
+> ***Look away to windward***\
+> ***You can see it's going to blow***\
+> ***Look at the glass***\
+> ***You can see that it is fell***\
+> ***We wish the you would hurry up***\
+> ***And strike, strike the bell***
 
 Down on the maindeck\
 Working at the pumps\

--- a/songs/The-Hog-Eye-Man.md
+++ b/songs/The-Hog-Eye-Man.md
@@ -15,11 +15,9 @@ When they come down from San Francisco
 
 *With a hog-eye*
 
-> *Railroad navvy with his hog-eye*
->
-> *Oh, you roll ashore with a hog-eye oh*
->
-> *She wants the hog-eyed man*
+> ***Railroad navvy with his hog-eye*** \
+> ***Oh, you roll ashore with a hog-eye oh*** \
+> ***She wants the hog-eyed man***
 
 So off and hand and primed is he
 

--- a/songs/The-Northwest-Passage.md
+++ b/songs/The-Northwest-Passage.md
@@ -10,7 +10,7 @@ tags:
   - song
 date: 2019-03-07T08:05:12.000Z
 ---
->Ah, for just one time I would take the Northwest Passage\
+> Ah, for just one time I would take the Northwest Passage\
 To find the hand of Franklin reaching for the Beaufort sea;\
 Tracing one warm line through a land so wide and savage\
 And make a Northwest Passage to the sea.

--- a/songs/The-Northwest-Passage.md
+++ b/songs/The-Northwest-Passage.md
@@ -10,7 +10,7 @@ tags:
   - song
 date: 2019-03-07T08:05:12.000Z
 ---
-> Ah, for just one time I would take the Northwest Passage\
+> ***Ah, for just one time I would take the Northwest Passage***\
 To find the hand of Franklin reaching for the Beaufort sea;\
 Tracing one warm line through a land so wide and savage\
 And make a Northwest Passage to the sea.

--- a/songs/Three-Score-And-Ten.md
+++ b/songs/Three-Score-And-Ten.md
@@ -41,14 +41,14 @@ A crew with hearts so brave
 Going out to earn their daily bread
 Upon the restless wave
 
-_And it's three score and ten
+And it's three score and ten
 Boys and men were lost from Grimsby town
 From Yarmouth down to Scarborough
 Many hundreds more were drowned
 Our herring craft, our Trawlers
 Our fishing Smacks, as well
 They long to fight the bitter night
-And battle with the swell_
+And battle with the swell
 
 Methinks I see them yet again\
 As they leave this land behind\

--- a/songs/Toms-Gone-To-Hilo.md
+++ b/songs/Toms-Gone-To-Hilo.md
@@ -8,11 +8,11 @@ date: 2019-03-07T08:05:12.000Z
 ---
 Tommy\'s gone, and I'll go too
 
->Away down Hilo
+> Away down Hilo
 
 Tommy\'s gone, what will I do?
 
->Tom\'s gone to Hilo
+> Tom\'s gone to Hilo
 
 Tommy\'s gone to Liverpool
 

--- a/songs/Toms-Gone-To-Hilo.md
+++ b/songs/Toms-Gone-To-Hilo.md
@@ -8,11 +8,11 @@ date: 2019-03-07T08:05:12.000Z
 ---
 Tommy\'s gone, and I'll go too
 
-> Away down Hilo
+> ***Away down Hilo***
 
 Tommy\'s gone, what will I do?
 
-> Tom\'s gone to Hilo
+> ***Tom\'s gone to Hilo***
 
 Tommy\'s gone to Liverpool
 

--- a/songs/Towrope-Girls.md
+++ b/songs/Towrope-Girls.md
@@ -15,10 +15,10 @@ Or Oregon timber in the fog and the rain\
 But we're loading nitrate at old iquique\
 And the girls have a got a hold of our tow rope today
 
-_Goodbye Serafina, Rosita and Luz,_\
-_The girls on the tow rope are steady and true,_\
-_Mothers and sisters and sweethearts and all,_\
-_It's haul away! All the way! Haul away haul!_
+***Goodbye Serafina, Rosita and Luz,***\
+***The girls on the tow rope are steady and true,***\
+***Mothers and sisters and sweethearts and all,***\
+***It's haul away! All the way! Haul away haul!***
 
 The last sack of nitrate is stowed down at last\
 The southern cross burns at the head of the mast\

--- a/songs/What-Shall-We-Do-With-The-Drunken-Sailor.md
+++ b/songs/What-Shall-We-Do-With-The-Drunken-Sailor.md
@@ -9,7 +9,7 @@ date: 2019-03-07T08:05:12.000Z
 ---
 What shall we do with the drunken sailor
 
->What shall we do with the drunken sailor
+> What shall we do with the drunken sailor
 What shall we do with the drunken sailor
 Early in the morning
 Weigh heigh and up she rises

--- a/songs/What-Shall-We-Do-With-The-Drunken-Sailor.md
+++ b/songs/What-Shall-We-Do-With-The-Drunken-Sailor.md
@@ -9,7 +9,7 @@ date: 2019-03-07T08:05:12.000Z
 ---
 What shall we do with the drunken sailor
 
-> What shall we do with the drunken sailor
+> ***What shall we do with the drunken sailor***
 What shall we do with the drunken sailor
 Early in the morning
 Weigh heigh and up she rises

--- a/songs/away-santianna.md
+++ b/songs/away-santianna.md
@@ -12,36 +12,36 @@ tags:
 date: 2019-03-13T22:54:34.527Z
 ---
 The Navy would never have a lass at sea\
-*Away Santianna*\
+***Away Santianna***\
 So I went in search of piracy\
-*All along the coast of Mexico*
+***All along the coast of Mexico***
 
-> So heave her up and away we'll go\
-> *Heave away Santianna*\
-> To Mexico where the warm winds blow\
-> *All along the coast of Mexico*
+> ***So heave her up and away we'll go***\
+> ***Heave away Santianna***\
+> ***To Mexico where the warm winds blow***\
+> ***All along the coast of Mexico***
 
 And now we sail the Southern Seas\
-*Away Santianna*\
+***Away Santianna***\
 And we'll have those lads down on their knees\
-*All along the coast of Mexico*
+***All along the coast of Mexico***
 
 In Mexico I want to be\
-*Away Santianna*\
+***Away Santianna***\
 With a cask of rum on a drinkin' spree\
-*All along the coast of Mexico*
+***All along the coast of Mexico***
 
 When I was a young lass in my prime\
-*Away Santianna*\
+***Away Santianna***\
 I had them Irish lads two at a time\
-*All along the coast of Mexico*
+***All along the coast of Mexico***
 
 But I'd never leave the sea to settle down\
-*Away Santianna*\
+***Away Santianna***\
 When I can have a man in every town\
-*All along the coast of Mexico*
+***All along the coast of Mexico***
 
 The times is hard and the riches low\
-*Away Santianna*\
+***Away Santianna***\
 But we pirates must "row and yo”\
-*All along the coast of Mexico*
+***All along the coast of Mexico***

--- a/songs/barge-ballad-barge-ballad.md
+++ b/songs/barge-ballad-barge-ballad.md
@@ -21,51 +21,51 @@ description: >-
   The chorus changes after every verse!
 ---
 Once there was a barge lad\
-_Way up atop the mast_\
+***Way up atop the mast***\
 Shouting to the skipper "we've made it home at last"\
 Well I was that barge lad\
-_Way up atop the mast_\
+***Way up atop the mast***\
 But now I'm the skipper and that young nipper had better be holding fast
 
-> _Oh, we're loaded down with bales so high_\
-> _You've got to lean backwards if you want to see the sky_\
-> _Oh, the Thames may forgive us, but the old never will_\
-> _So eyes front and away we sail_
+> ***Oh, we're loaded down with bales so high***\
+> ***You've got to lean backwards if you want to see the sky***\
+> ***Oh, the Thames may forgive us, but the old never will***\
+> ***So eyes front and away we sail***
 
 Oh, you've got to be able\
-_Way up atop the mast_\
+***Way up atop the mast***\
 Your legs better be nimble and your head better think fast\
 Well I was that able\
-_Way up atop the mast_\
+***Way up atop the mast***\
 But now I'm the skipper and that young nipper is hardy enough to last
 
-> _Oh, we're loaded down with bales so high_\
-> _You've got to lean backwards if you want to see the sky_\
-> _Oh, the Thames may forgive us, but the old never will_\
-> _So eyes front, keep your head, and away we sail_
+> ***Oh, we're loaded down with bales so high***\
+> ***You've got to lean backwards if you want to see the sky***\
+> ***Oh, the Thames may forgive us, but the old never will***\
+> ***So eyes front, keep your head, and away we sail***
 
 Oh, you've eyes like an eagle\
-_Way up atop the mast_\
+***Way up atop the mast***\
 Spotting all the obstacles that come across your path\
 Well, I was that eagle\
-_Way up atop the mast_\
+***Way up atop the mast***\
 But now I'm the skipper and that young nipper will keep us from taking a bath
 
-> _Oh, we're loaded down with bales so high_\
-> _You've got to lean backwards if you want to see the sky_\
-> _Oh, the Thames may forgive us, but the old never will_\
-> _So eyes front, keep your head, clear your throat, and away we sail_
+> ***Oh, we're loaded down with bales so high***\
+> ***You've got to lean backwards if you want to see the sky***\
+> ***Oh, the Thames may forgive us, but the old never will***\
+> ***So eyes front, keep your head, clear your throat, and away we sail***
 
 Oh, you've got to remember\
-_Way up atop the mast_\
+***Way up atop the mast***\
 Knowing all the river routes that you never learn from the charts\
 Well, I do remember\
-_Way up atop the mast_\
+***Way up atop the mast***\
 But now I'm the skipper and that young nipper is taking the rivers to heart
 
-> _Oh, we're loaded down with bales so high_\
-> _You've got to lean backwards if you want to see the sky_\
-> _Oh, the Thames may forgive us, but the old never will_\
-> _So eyes front, keep your head, clear your throat,_\
-> _Know your way, fill your pipe,_\
-> _Grab on tight, look for the light and away we sail_
+> ***Oh, we're loaded down with bales so high***\
+> ***You've got to lean backwards if you want to see the sky***\
+> ***Oh, the Thames may forgive us, but the old never will***\
+> ***So eyes front, keep your head, clear your throat,***\
+> ***Know your way, fill your pipe,***\
+> ***Grab on tight, look for the light and away we sail***

--- a/songs/barge-ballad-barge-ballad.md
+++ b/songs/barge-ballad-barge-ballad.md
@@ -27,10 +27,10 @@ Well I was that barge lad\
 _Way up atop the mast_\
 But now I'm the skipper and that young nipper had better be holding fast
 
->_Oh, we're loaded down with bales so high_\
->_You've got to lean backwards if you want to see the sky_\
->_Oh, the Thames may forgive us, but the old never will_\
->_So eyes front and away we sail_
+> _Oh, we're loaded down with bales so high_\
+> _You've got to lean backwards if you want to see the sky_\
+> _Oh, the Thames may forgive us, but the old never will_\
+> _So eyes front and away we sail_
 
 Oh, you've got to be able\
 _Way up atop the mast_\
@@ -39,10 +39,10 @@ Well I was that able\
 _Way up atop the mast_\
 But now I'm the skipper and that young nipper is hardy enough to last
 
->_Oh, we're loaded down with bales so high_\
->_You've got to lean backwards if you want to see the sky_\
->_Oh, the Thames may forgive us, but the old never will_\
->_So eyes front, keep your head, and away we sail_
+> _Oh, we're loaded down with bales so high_\
+> _You've got to lean backwards if you want to see the sky_\
+> _Oh, the Thames may forgive us, but the old never will_\
+> _So eyes front, keep your head, and away we sail_
 
 Oh, you've eyes like an eagle\
 _Way up atop the mast_\
@@ -51,10 +51,10 @@ Well, I was that eagle\
 _Way up atop the mast_\
 But now I'm the skipper and that young nipper will keep us from taking a bath
 
->_Oh, we're loaded down with bales so high_\
->_You've got to lean backwards if you want to see the sky_\
->_Oh, the Thames may forgive us, but the old never will_\
->_So eyes front, keep your head, clear your throat, and away we sail_
+> _Oh, we're loaded down with bales so high_\
+> _You've got to lean backwards if you want to see the sky_\
+> _Oh, the Thames may forgive us, but the old never will_\
+> _So eyes front, keep your head, clear your throat, and away we sail_
 
 Oh, you've got to remember\
 _Way up atop the mast_\
@@ -63,9 +63,9 @@ Well, I do remember\
 _Way up atop the mast_\
 But now I'm the skipper and that young nipper is taking the rivers to heart
 
->_Oh, we're loaded down with bales so high_\
->_You've got to lean backwards if you want to see the sky_\
->_Oh, the Thames may forgive us, but the old never will_\
->_So eyes front, keep your head, clear your throat,_\
->_Know your way, fill your pipe,_\
->_Grab on tight, look for the light and away we sail_
+> _Oh, we're loaded down with bales so high_\
+> _You've got to lean backwards if you want to see the sky_\
+> _Oh, the Thames may forgive us, but the old never will_\
+> _So eyes front, keep your head, clear your throat,_\
+> _Know your way, fill your pipe,_\
+> _Grab on tight, look for the light and away we sail_

--- a/songs/blood-red-roses-blood-red-roses.md
+++ b/songs/blood-red-roses-blood-red-roses.md
@@ -11,39 +11,39 @@ tags:
 date: 2019-03-14T19:43:26.974Z
 ---
 Our boots and clothes is all in pawn,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 And its flamin' drafty 'round Cape Horn.
 
-> _Go down, you blood red roses, go down!_\
-> _Oh, you pinks and posies,_\
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***\
+> ***Oh, you pinks and posies,***\
+> ***Go down, you blood red roses, go down!***
 
 It's 'round that cape we all must go,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 Around all stiff through the frost and snow.
 
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***
 
 Our captain he has set us down,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 And he has sailed till Auckland town.\
 
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***
 
 Oh my old mother, she wrote to me,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 My dearest son, come home from sea.
 
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***
 
 It's growl you may, but go you must,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 If you growl too hard your head they'll bust.
 
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***
 
 Just one more pull and that will do,\
-_Go down, you blood red roses, go down!_\
+***Go down, you blood red roses, go down!***\
 Just one more pull to see us through.
 
-> _Go down, you blood red roses, go down!_
+> ***Go down, you blood red roses, go down!***

--- a/songs/blood-red-roses-blood-red-roses.md
+++ b/songs/blood-red-roses-blood-red-roses.md
@@ -14,36 +14,36 @@ Our boots and clothes is all in pawn,\
 _Go down, you blood red roses, go down!_\
 And its flamin' drafty 'round Cape Horn.
 
->_Go down, you blood red roses, go down!_\
->_Oh, you pinks and posies,_\
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_\
+> _Oh, you pinks and posies,_\
+> _Go down, you blood red roses, go down!_
 
 It's 'round that cape we all must go,\
 _Go down, you blood red roses, go down!_\
 Around all stiff through the frost and snow.
 
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_
 
 Our captain he has set us down,\
 _Go down, you blood red roses, go down!_\
 And he has sailed till Auckland town.\
 
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_
 
 Oh my old mother, she wrote to me,\
 _Go down, you blood red roses, go down!_\
 My dearest son, come home from sea.
 
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_
 
 It's growl you may, but go you must,\
 _Go down, you blood red roses, go down!_\
 If you growl too hard your head they'll bust.
 
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_
 
 Just one more pull and that will do,\
 _Go down, you blood red roses, go down!_\
 Just one more pull to see us through.
 
->_Go down, you blood red roses, go down!_
+> _Go down, you blood red roses, go down!_

--- a/songs/broadside-broadside.md
+++ b/songs/broadside-broadside.md
@@ -33,33 +33,33 @@ For there’s nothing like dominion of the water\
 From the rocky coast of Kerry to the bloody Spanish Main\
 It’s the best thing you can ever teach your daughter
 
-> _Broadside to broadside, two captains collide_\
-> _Queen of the spheres and queen of the tide_\
-> _Regalia and rebellion go sailing side by side_\
-> _Haul away, sister, haul away_
+> ***Broadside to broadside, two captains collide***\
+> ***Queen of the spheres and queen of the tide***\
+> ***Regalia and rebellion go sailing side by side***\
+> ***Haul away, sister, haul away***
 
 Plunder men for treasure, and never heed their blows\
 For there’s nothing given freely to a woman\
 Be generous to friendship and lavish to your foes\
 Then pirate queens may share the seas in common
 
-> _Broadside to broadside, two captains collide..._
+> ***Broadside to broadside, two captains collide...***
 
 Blades are bared for battle, these queens of half the world\
 And cannons primed and ready with their thunder\
 They know just what they fight for when the flag o’ war’s unfurled\
 It’s freedom they’ll be seizing with their plunder
 
-> _Broadside to broadside, two captains collide..._
+> ***Broadside to broadside, two captains collide...***
 
 For blows will make you weary and marriage make a slave\
 You’d be better on the sea like brave O’Malley\
 And when that gallant vessel goes a rolling on the wave\
 Be sure you’re on the deck not in the galley
 
-> _Broadside to broadside, two captains collide_\
-> _Queen of the spheres and queen of the tide_\
-> _Regalia and rebellion go sailing side by side_\
-> _Haul away, sister,_\
-> _Haul away, sister,_\
-> _Haul away, sister, haul away_
+> ***Broadside to broadside, two captains collide***\
+> ***Queen of the spheres and queen of the tide***\
+> ***Regalia and rebellion go sailing side by side***\
+> ***Haul away, sister,***\
+> ***Haul away, sister,***\
+> ***Haul away, sister, haul away***

--- a/songs/broadside-broadside.md
+++ b/songs/broadside-broadside.md
@@ -33,33 +33,33 @@ For there’s nothing like dominion of the water\
 From the rocky coast of Kerry to the bloody Spanish Main\
 It’s the best thing you can ever teach your daughter
 
->_Broadside to broadside, two captains collide_\
->_Queen of the spheres and queen of the tide_\
->_Regalia and rebellion go sailing side by side_\
->_Haul away, sister, haul away_
+> _Broadside to broadside, two captains collide_\
+> _Queen of the spheres and queen of the tide_\
+> _Regalia and rebellion go sailing side by side_\
+> _Haul away, sister, haul away_
 
 Plunder men for treasure, and never heed their blows\
 For there’s nothing given freely to a woman\
 Be generous to friendship and lavish to your foes\
 Then pirate queens may share the seas in common
 
->_Broadside to broadside, two captains collide..._
+> _Broadside to broadside, two captains collide..._
 
 Blades are bared for battle, these queens of half the world\
 And cannons primed and ready with their thunder\
 They know just what they fight for when the flag o’ war’s unfurled\
 It’s freedom they’ll be seizing with their plunder
 
->_Broadside to broadside, two captains collide..._
+> _Broadside to broadside, two captains collide..._
 
 For blows will make you weary and marriage make a slave\
 You’d be better on the sea like brave O’Malley\
 And when that gallant vessel goes a rolling on the wave\
 Be sure you’re on the deck not in the galley
 
->_Broadside to broadside, two captains collide_\
->_Queen of the spheres and queen of the tide_\
->_Regalia and rebellion go sailing side by side_\
->_Haul away, sister,_\
->_Haul away, sister,_\
->_Haul away, sister, haul away_
+> _Broadside to broadside, two captains collide_\
+> _Queen of the spheres and queen of the tide_\
+> _Regalia and rebellion go sailing side by side_\
+> _Haul away, sister,_\
+> _Haul away, sister,_\
+> _Haul away, sister, haul away_

--- a/songs/crossing-the-bar-crossing-the-bar.md
+++ b/songs/crossing-the-bar-crossing-the-bar.md
@@ -15,37 +15,37 @@ And one clear call for me!\
 And may there be no moaning of the bar\
 When I put out to sea.
 
-> _When I put out to sea,_\
-> _When I put out to sea._\
-> _And may there be no moaning of the bar_\
-> _When I put out to sea._
+> ***When I put out to sea,***\
+> ***When I put out to sea.***\
+> ***And may there be no moaning of the bar***\
+> ***When I put out to sea.***
 
 But such a tide as moving seems asleep,\
 Too full for sound and foam,\
 When that which drew from out the boundless deep\
 Turns again home.
 
-> _Turns again home,_\
-> _Turns again home,_\
-> _When that which drew from out the boundless deep_\
-> _Turns again home._
+> ***Turns again home,***\
+> ***Turns again home,***\
+> ***When that which drew from out the boundless deep***\
+> ***Turns again home.***
 
 Twilight and evening bell,\
 And after that the dark!\
 And may there be no sadness of farewell\
 When I embark.
 
-> _When I embark,_\
-> _When I embark,_\
-> _And may there be no sadness of farewell_\
-> _When I embark._
+> ***When I embark,***\
+> ***When I embark,***\
+> ***And may there be no sadness of farewell***\
+> ***When I embark.***
 
 For though from out our bourne of time and place\
 The flood may bear me far,\
 I hope to see my Pilot face to face\
 When I have crossed the bar.
 
-> _When I have crossed the bar,_\
-> _When I have crossed the bar,_\
-> _I hope to see my Pilot face to face_\
-> _When I have crossed the bar._
+> ***When I have crossed the bar,***\
+> ***When I have crossed the bar,***\
+> ***I hope to see my Pilot face to face***\
+> ***When I have crossed the bar.***

--- a/songs/crossing-the-bar-crossing-the-bar.md
+++ b/songs/crossing-the-bar-crossing-the-bar.md
@@ -15,37 +15,37 @@ And one clear call for me!\
 And may there be no moaning of the bar\
 When I put out to sea.
 
->_When I put out to sea,_\
->_When I put out to sea._\
->_And may there be no moaning of the bar_\
->_When I put out to sea._
+> _When I put out to sea,_\
+> _When I put out to sea._\
+> _And may there be no moaning of the bar_\
+> _When I put out to sea._
 
 But such a tide as moving seems asleep,\
 Too full for sound and foam,\
 When that which drew from out the boundless deep\
 Turns again home.
 
->_Turns again home,_\
->_Turns again home,_\
->_When that which drew from out the boundless deep_\
->_Turns again home._
+> _Turns again home,_\
+> _Turns again home,_\
+> _When that which drew from out the boundless deep_\
+> _Turns again home._
 
 Twilight and evening bell,\
 And after that the dark!\
 And may there be no sadness of farewell\
 When I embark.
 
->_When I embark,_\
->_When I embark,_\
->_And may there be no sadness of farewell_\
->_When I embark._
+> _When I embark,_\
+> _When I embark,_\
+> _And may there be no sadness of farewell_\
+> _When I embark._
 
 For though from out our bourne of time and place\
 The flood may bear me far,\
 I hope to see my Pilot face to face\
 When I have crossed the bar.
 
->_When I have crossed the bar,_\
->_When I have crossed the bar,_\
->_I hope to see my Pilot face to face_\
->_When I have crossed the bar._
+> _When I have crossed the bar,_\
+> _When I have crossed the bar,_\
+> _I hope to see my Pilot face to face_\
+> _When I have crossed the bar._

--- a/songs/docks-shanty-docks-shanty.md
+++ b/songs/docks-shanty-docks-shanty.md
@@ -35,31 +35,31 @@ But away 'cross the waves I am forced now to fly,\
 For the king whom I faithfully once bent my knee,\
 Has taken my lover away from me
 
-_So I'll paint my sails red, and I'll sail out to sea,_\
-_And I don't care who they send to subjugate me_\
-_With my axe I'll avenge on this patriarchy,_\
-_On those w’took my lover, away from me_
+***So I'll paint my sails red, and I'll sail out to sea,***\
+***And I don't care who they send to subjugate me***\
+***With my axe I'll avenge on this patriarchy,***\
+***On those w’took my lover, away from me***
 
 Now boys look on the ramparts, your father's up there,\
 Or his head is at least and his body's somewhere,\
 Though your eyes fill with pity, my own fill with rage,\
 We will have our vengeance, I swear it this day
 
-_So I'll paint my sails red, and I'll sail out to sea,_\
-_And I don't care who they send to subjugate me,_\
-_With my axe I'll avenge on this patriarchy,_\
-_On those w’took my lover, away from me_
+***So I'll paint my sails red, and I'll sail out to sea,***\
+***And I don't care who they send to subjugate me,***\
+***With my axe I'll avenge on this patriarchy,***\
+***On those w’took my lover, away from me***
 
 So the French call me "traitor", that England is "home",\
 Though I fight for myself, I am no-ones to own,\
 'long this small stretch of coastline, shall my ship sail free,\
 A nightmare before whom the French will soon flee
 
-_So I'll paint my sails red, and I'll sail out to sea..._\
-\
+***So I'll paint my sails red, and I'll sail out to sea...***
+
 Oh my name is De Clisson, a pirate am I,\
 And as mother and matriarch proudly I'll die,\
 And those men who so bravely, besmirch'd my name,\
 So quickly turn cowards out here on the main
 
-_So I'll paint my sails red, and I'll sail out to sea..._
+***So I'll paint my sails red, and I'll sail out to sea...***

--- a/songs/dont-forget-your-old-shipmate-dont-forget-your-old-shipmate.md
+++ b/songs/dont-forget-your-old-shipmate-dont-forget-your-old-shipmate.md
@@ -16,45 +16,45 @@ Let the waters roar, Jack\
 Safe and sound at home again\
 Let the waters roar, Jack
 
->_Long we've tossed on the rolling main_\
->_Now we're safe ashore, Jack_\
->_Don't forget your old shipmate_\
->_Fal dee ral dee ral dee rye eye doe!_
+> _Long we've tossed on the rolling main_\
+> _Now we're safe ashore, Jack_\
+> _Don't forget your old shipmate_\
+> _Fal dee ral dee ral dee rye eye doe!_
 
 Since we sailed from Plymouth Sound\
 Four years gone, or nigh, Jack\
 Was there ever chummies, now\
 Such as you and I, Jack?
 
->_Long we've tossed on the rolling main..._
+> _Long we've tossed on the rolling main..._
 
 We have worked the self-same gun:\
 Quarterdeck division\
 Sponger I and loader you\
 Through the whole commission
 
->_Long we've tossed on the rolling main..._
+> _Long we've tossed on the rolling main..._
 
 Oftentimes have we laid out\
 toil nor danger fearing,\
 Tugging out the flapping sail\
 to the weather bearing
 
->_Long we've tossed on the rolling main..._
+> _Long we've tossed on the rolling main..._
 
 When the middle watch was on\
 And the time went slow, boy\
 Who could choose a rousing stave\
 Who like Jack or Joe, boy?
 
->_Long we've tossed on the rolling main..._
+> _Long we've tossed on the rolling main..._
 
 There she swings, an empty hulk\
 Not a soul below now\
 Number seven starboard mess\
 Misses Jack and Joe now
 
->_Long we've tossed on the rolling main..._
+> _Long we've tossed on the rolling main..._
 
 But the best of friends must part\
 Fair or foul the weather\

--- a/songs/dont-forget-your-old-shipmate-dont-forget-your-old-shipmate.md
+++ b/songs/dont-forget-your-old-shipmate-dont-forget-your-old-shipmate.md
@@ -16,45 +16,45 @@ Let the waters roar, Jack\
 Safe and sound at home again\
 Let the waters roar, Jack
 
-> _Long we've tossed on the rolling main_\
-> _Now we're safe ashore, Jack_\
-> _Don't forget your old shipmate_\
-> _Fal dee ral dee ral dee rye eye doe!_
+> ***Long we've tossed on the rolling main***\
+> ***Now we're safe ashore, Jack***\
+> ***Don't forget your old shipmate***\
+> ***Fal dee ral dee ral dee rye eye doe!***
 
 Since we sailed from Plymouth Sound\
 Four years gone, or nigh, Jack\
 Was there ever chummies, now\
 Such as you and I, Jack?
 
-> _Long we've tossed on the rolling main..._
+> ***Long we've tossed on the rolling main...***
 
 We have worked the self-same gun:\
 Quarterdeck division\
 Sponger I and loader you\
 Through the whole commission
 
-> _Long we've tossed on the rolling main..._
+> ***Long we've tossed on the rolling main...***
 
 Oftentimes have we laid out\
 toil nor danger fearing,\
 Tugging out the flapping sail\
 to the weather bearing
 
-> _Long we've tossed on the rolling main..._
+> ***Long we've tossed on the rolling main...***
 
 When the middle watch was on\
 And the time went slow, boy\
 Who could choose a rousing stave\
 Who like Jack or Joe, boy?
 
-> _Long we've tossed on the rolling main..._
+> ***Long we've tossed on the rolling main...***
 
 There she swings, an empty hulk\
 Not a soul below now\
 Number seven starboard mess\
 Misses Jack and Joe now
 
-> _Long we've tossed on the rolling main..._
+> ***Long we've tossed on the rolling main...***
 
 But the best of friends must part\
 Fair or foul the weather\

--- a/songs/female-smuggler-female-smuggler.md
+++ b/songs/female-smuggler-female-smuggler.md
@@ -19,49 +19,49 @@ description: >-
 Come listen awhile and you soon shall hear\
 By the rolling sea lived a maiden fair\
 Her father was of the smuggling trade\
-_Like a war-like hero, like a war-like hero, she never was afraid_
+***Like a war-like hero, like a war-like hero, she never was afraid***
 
 Now, in sailor's clothing swell Jane did go,\
 Dressed like a sailor from top to toe;\
 Her aged father was the only care\
-_Of this female smuggler, of this female smuggler, who never did despair._
+***Of this female smuggler, of this female smuggler, who never did despair.***
 
 With her pistols loaded she went aboard.\
 And by her side hung a glittering sword,\
 In her belt two daggers; well armed for war\
-_Was this female smuggler, was this female smuggler, who never feared a scar._
+***Was this female smuggler, was this female smuggler, who never feared a scar.***
 
 Now they had not sail-ed far from the land,\
 When a strange sail brought them to a stand.\
 "These are sea robbers," this maid did cry,\
-_"But the female smuggler, but the female smuggler, will conquer or will die."_
+***"But the female smuggler, but the female smuggler, will conquer or will die."***
 
 Alongside, then, this strange vessel came.\
 "Cheer up " cried Jane," we will board the same;\
 We'll run all chances to rise or fall,"\
-_Cried this female smuggler, cried this female smuggler, who never feared a ball._
+***Cried this female smuggler, cried this female smuggler, who never feared a ball.***
 
 Now they killed those pirates and took their store,\
 And soon returned to Old England's shore.\
 With a keg of brandy she walked along,\
-_Did this female smuggler, did this female smuggler, who sweetly sang a song._
+***Did this female smuggler, did this female smuggler, who sweetly sang a song.***
 
 Now they were followed by the blockade,\
 Who in irons strong did put this young maid.\
 But when they brought her to be tried,\
-_This young female smuggler, this young female smuggler, stood dressed like a bride._
+***This young female smuggler, this young female smuggler, stood dressed like a bride.***
 
 Their commodore against her appeared,\
 And for her life she greatly feared.\
 When he did find to his great surprise\
-_'Twas a female smuggler, 'twas a female smuggler, had fought him in disguise._
+***'Twas a female smuggler, 'twas a female smuggler, had fought him in disguise.***
 
 He to the judge and jury said,\
 "l cannot prosecute this maid,\
 Pardon for her on my knees I crave,\
-_For this female smuggler, for this female smuggler, so valiant and so brave."_
+***For this female smuggler, for this female smuggler, so valiant and so brave."***
 
 Then this commodore to her father went,\
 To gain her hand he asked his consent.\
 His consent and hers he got, so the commodore\
-_And the female smuggler, and the female smuggler, are one for evermore._
+***And the female smuggler, and the female smuggler, are one for evermore.***

--- a/songs/flora-and-james-flora-and-james.md
+++ b/songs/flora-and-james-flora-and-james.md
@@ -19,40 +19,40 @@ Come all you true lovers attend for a while to a tale I am going to unfold! \
 Young James was a lad who was virtuous and kind, and Flora a sailor so bold. \
 “Adieu! Lovely James!” One morning said she, “We are called, I am forced for to go, \
 Far from my native shore, when the loud cannons roar, up aloft when the stormy winds blow.” \
-_Up aloft when the stormy winds blow!_ \
-_Far from my native shore, when the loud cannons roar, up aloft when the stormy winds blow._
+***Up aloft when the stormy winds blow!*** \
+***Far from my native shore, when the loud cannons roar, up aloft when the stormy winds blow.***
 
 Oh James how he wept, sad tears from his blue eyes, when young Flora said she must depart \
 She broke her ring in two, said “Here's one half for you” and the other she pressed to her heart. \
 James wept in despair, tore at his lovely hair, saying “Flora, with you I must go” \
 Crying in accents soft “I shall go up aloft with my love, when the stormy winds blow.” \
-_With my love, when the stormy winds blow!_ \
-_Crying in accents soft “I shall go up aloft with my love, when the stormy winds blow.”_
+***With my love, when the stormy winds blow!*** \
+***Crying in accents soft “I shall go up aloft with my love, when the stormy winds blow.”***
 
 Said Flora, “Dear James, you surely can't think for to risk your sweet life on the deep? \
 And for to go aloft, when on your pillow soft, contented at home you might sleep!” \
 He said “I'm not afraid, and none shall me persuade, as determined I am for to go \
 Unto some foreign shore where the loud cannons roar, to be with you when stormy winds blow.” \
-_To be with you when stormy winds blow_ \
-_Unto some foreign shore where the loud cannons roar, to be with you when stormy winds blow.”_ 
+***To be with you when stormy winds blow*** \
+***Unto some foreign shore where the loud cannons roar, to be with you when stormy winds blow.”*** 
 
 Two sailors they shipped out, these lovers so true (for indeed there's no gender in war), \
 And though James was afraid, with his Flora he stayed for true love, for their comrades, and more. \
 By day and by night these two lovers did fight, and with grit in to battle did go \
 Taking no joy in war, many hardships they bore up aloft when the stormy winds blow. \
-_Up aloft when the stormy winds blow_ \
-_Taking no joy in war, many hardships they bore up aloft when the stormy winds blow._
+***Up aloft when the stormy winds blow*** \
+***Taking no joy in war, many hardships they bore up aloft when the stormy winds blow.***
 
 Five years on the ocean these two they did sail, respected by all the ship's crew. \
 And not one did care how young James wore his hair; they know men can be fine sailors too. \
 On the bow they did stand, side by side, hand in hand, before once more aloft they did go, \
 With no care for his life, James followed his wife up aloft when the stormy winds blow. \
-_Up aloft when the stormy winds blow_ \
-_With no care for his life, James followed his wife up aloft when the stormy winds blow._
+***Up aloft when the stormy winds blow*** \
+***With no care for his life, James followed his wife up aloft when the stormy winds blow.***
 
 Just a year more had past when young Flora - at last - had the Captaincy gifted with gold \
 At the front of the crowd stood young James, and so proud of his Flora he loved to behold. \
 So on went the sailors, the lovers, to sea, for when the fight stops, who can know? \
 But until the war's o'er there's a young lovers bower up aloft when the stormy winds blow. \
-_Up aloft when the stormy winds blow._ \
-_But until the war's o'er there's a young lovers bower up aloft when the stormy winds blow._
+***Up aloft when the stormy winds blow.*** \
+***But until the war's o'er there's a young lovers bower up aloft when the stormy winds blow.***

--- a/songs/fragile-water-fragile-water.md
+++ b/songs/fragile-water-fragile-water.md
@@ -22,20 +22,20 @@ Cold and slender as a secret river\
 And glamour folds within my hand\
 Like a salmon skin of beaten silver
 
-> _My little fish slip off your skin_\
-> _And leave it in the tide for gulls to plunder_\
-> _And if you wish to walk or swim_\
-> _Let there be nothing in the world to hinder_
+> ***My little fish slip off your skin***\
+> ***And leave it in the tide for gulls to plunder***\
+> ***And if you wish to walk or swim***\
+> ***Let there be nothing in the world to hinder***
 
 I cannot walk among your kin\
 For after water, land seems so much harder\
 But I will fall from wandering\
 To land on beaten sand and fragile water
 
-> _My little fish slip off your skin_\
-> _And leave it in the tide for gulls to plunder_\
-> _And if you wish to walk or swim_\
-> _Let there be nothing in the world to hinder_
+> ***My little fish slip off your skin***\
+> ***And leave it in the tide for gulls to plunder***\
+> ***And if you wish to walk or swim***\
+> ***Let there be nothing in the world to hinder***
 
 There are other gifts than silver\
 Like another word for lover\
@@ -52,15 +52,15 @@ But as the ocean courts the strand\
 So generations may understand\
 We are all beaten sand and fragile water
 
-> _My little fish slip off your skin_\
-> _And leave it in the tide for gulls to plunder_\
-> _And if you wish to walk or swim_\
-> _Let there be nothing in the world to hinder_
+> ***My little fish slip off your skin***\
+> ***And leave it in the tide for gulls to plunder***\
+> ***And if you wish to walk or swim***\
+> ***Let there be nothing in the world to hinder***
 >
-> _My little fish slip off your skin_\
-> _And leave it in the tide for gulls to plunder_\
-> _And if you wish to walk or swim_\
-> _Let there be nothing in the world to hinder_
+> ***My little fish slip off your skin***\
+> ***And leave it in the tide for gulls to plunder***\
+> ***And if you wish to walk or swim***\
+> ***Let there be nothing in the world to hinder***
 
 There are other gifts than silver\
 Like another word for lover\
@@ -71,4 +71,4 @@ There are other gifts for silver\
 Like another word for lover\
 If we only hold each other\
 We are beaten sand and fragile water\
-_We are beaten sand and fragile water_
+***We are beaten sand and fragile water***

--- a/songs/fragile-water-fragile-water.md
+++ b/songs/fragile-water-fragile-water.md
@@ -22,20 +22,20 @@ Cold and slender as a secret river\
 And glamour folds within my hand\
 Like a salmon skin of beaten silver
 
->_My little fish slip off your skin_\
->_And leave it in the tide for gulls to plunder_\
->_And if you wish to walk or swim_\
->_Let there be nothing in the world to hinder_
+> _My little fish slip off your skin_\
+> _And leave it in the tide for gulls to plunder_\
+> _And if you wish to walk or swim_\
+> _Let there be nothing in the world to hinder_
 
 I cannot walk among your kin\
 For after water, land seems so much harder\
 But I will fall from wandering\
 To land on beaten sand and fragile water
 
->_My little fish slip off your skin_\
->_And leave it in the tide for gulls to plunder_\
->_And if you wish to walk or swim_\
->_Let there be nothing in the world to hinder_
+> _My little fish slip off your skin_\
+> _And leave it in the tide for gulls to plunder_\
+> _And if you wish to walk or swim_\
+> _Let there be nothing in the world to hinder_
 
 There are other gifts than silver\
 Like another word for lover\
@@ -52,15 +52,15 @@ But as the ocean courts the strand\
 So generations may understand\
 We are all beaten sand and fragile water
 
->_My little fish slip off your skin_\
->_And leave it in the tide for gulls to plunder_\
->_And if you wish to walk or swim_\
->_Let there be nothing in the world to hinder_
+> _My little fish slip off your skin_\
+> _And leave it in the tide for gulls to plunder_\
+> _And if you wish to walk or swim_\
+> _Let there be nothing in the world to hinder_
 >
->_My little fish slip off your skin_\
->_And leave it in the tide for gulls to plunder_\
->_And if you wish to walk or swim_\
->_Let there be nothing in the world to hinder_
+> _My little fish slip off your skin_\
+> _And leave it in the tide for gulls to plunder_\
+> _And if you wish to walk or swim_\
+> _Let there be nothing in the world to hinder_
 
 There are other gifts than silver\
 Like another word for lover\

--- a/songs/general-taylor-general-taylor.md
+++ b/songs/general-taylor-general-taylor.md
@@ -23,19 +23,19 @@ description: >-
   receives the ceremonial funeral traditionally given to Stormy.
 ---
 General Taylor's dead and gone\
-_Walk him along, John, carry him along_\
+***Walk him along, John, carry him along***\
 Oh, General Taylor's dead and gone\
-_Carry him to his burying ground_
+***Carry him to his burying ground***
 
-_To me way hey, you Stormy_\
-_Walk him along, John, carry him along_\
-_To me way hey, you Stormy_\
-_Carry him to his burying ground_
+***To me way hey, you Stormy***\
+***Walk him along, John, carry him along***\
+***To me way hey, you Stormy***\
+***Carry him to his burying ground***
 
 Oh I wish that I was old Stormy's son\
 I'd build him a ship o' ten thousand tons
 
-_To me way hey, you Stormy..._
+***To me way hey, you Stormy...***
 
 I'd load her down with ale and rum\
 And every shellback should have some

--- a/songs/grace-darling-grace-darling.md
+++ b/songs/grace-darling-grace-darling.md
@@ -32,10 +32,10 @@ Pure as the air around her, of danger ne'er afraid.\
 One morning just at daybreak a storm-tossed wreck she spied.\
 Although to try seemed madness,"I'll save the crew," she cried.
 
-_And she pulled away o'er the rolling seas, over the waters blue._\
-_"Help, help": she could hear the cry of the shipwrecked crew;_\
-_But Grace had an English heart: the raging storm she braved;_\
-_She pulled away 'mid the dashing spray, and the crew she saved._
+***And she pulled away o'er the rolling seas, over the waters blue.***\
+***"Help, help": she could hear the cry of the shipwrecked crew;***\
+***But Grace had an English heart: the raging storm she braved;***\
+***She pulled away 'mid the dashing spray, and the crew she saved.***
 
 They to the rocks were clinging, a crew of nine, all told;\
 Between them and the lighthouse the seas like mountains rolled.\

--- a/songs/greenland-whale-fisheries-greenland-whale-fisheries.md
+++ b/songs/greenland-whale-fisheries-greenland-whale-fisheries.md
@@ -20,7 +20,7 @@ Our good ship she did anchor weigh
 
 And for Greenland bore away, brave boys,
 
-> And for Greenland bore away.
+> ***And for Greenland bore away.***
 
 
 
@@ -32,7 +32,7 @@ There's a whale, there's a whale, there's a whale! he cried,
 
 And she blows at every span, brave boys,
 
-> And she blows at every span!
+> ***And she blows at every span!***
 
 
 
@@ -44,7 +44,7 @@ Overhaul, overhaul, let your davit tackles fall!
 
 And you put your boats to the sea, brave boys,
 
-> And you put your boats to the sea!
+> ***And you put your boats to the sea!***
 
 
 
@@ -56,7 +56,7 @@ And resolved was each sailor bold,
 
 To steer where the whalefish blew, brave boys,
 
-> To steer where the whalefish blew.
+> ***To steer where the whalefish blew.***
 
 
 
@@ -68,7 +68,7 @@ Our boat capsized and we lost five men
 
 And we did not catch that whale, brave boys,
 
-> And we did not catch that whale.
+> ***And we did not catch that whale.***
 
 
 
@@ -80,7 +80,7 @@ But, the loosing of that bloody sperm whale
 
 It grieved him ten times more, brave boys,
 
-> It grieved him ten times more!
+> ***It grieved him ten times more!***
 
 
 
@@ -92,7 +92,7 @@ There's ice and snow and the whale-fishies blow
 
 And the land never was green, brave boys,
 
-> And the land never was green
+> ***And the land never was green***
 
 
 
@@ -104,4 +104,4 @@ To stow below our running gear
 
 And from Greenland bear away, brave boys,
 
-> From Greenland bear away.
+> ***From Greenland bear away.***

--- a/songs/greenland-whale-fisheries-greenland-whale-fisheries.md
+++ b/songs/greenland-whale-fisheries-greenland-whale-fisheries.md
@@ -20,7 +20,7 @@ Our good ship she did anchor weigh
 
 And for Greenland bore away, brave boys,
 
->And for Greenland bore away.
+> And for Greenland bore away.
 
 
 
@@ -32,7 +32,7 @@ There's a whale, there's a whale, there's a whale! he cried,
 
 And she blows at every span, brave boys,
 
->And she blows at every span!
+> And she blows at every span!
 
 
 
@@ -44,7 +44,7 @@ Overhaul, overhaul, let your davit tackles fall!
 
 And you put your boats to the sea, brave boys,
 
->And you put your boats to the sea!
+> And you put your boats to the sea!
 
 
 
@@ -56,7 +56,7 @@ And resolved was each sailor bold,
 
 To steer where the whalefish blew, brave boys,
 
->To steer where the whalefish blew.
+> To steer where the whalefish blew.
 
 
 
@@ -68,7 +68,7 @@ Our boat capsized and we lost five men
 
 And we did not catch that whale, brave boys,
 
->And we did not catch that whale.
+> And we did not catch that whale.
 
 
 
@@ -80,7 +80,7 @@ But, the loosing of that bloody sperm whale
 
 It grieved him ten times more, brave boys,
 
->It grieved him ten times more!
+> It grieved him ten times more!
 
 
 
@@ -92,7 +92,7 @@ There's ice and snow and the whale-fishies blow
 
 And the land never was green, brave boys,
 
->And the land never was green
+> And the land never was green
 
 
 
@@ -104,4 +104,4 @@ To stow below our running gear
 
 And from Greenland bear away, brave boys,
 
->From Greenland bear away.
+> From Greenland bear away.

--- a/songs/health-to-the-company-health-to-the-company.md
+++ b/songs/health-to-the-company-health-to-the-company.md
@@ -19,21 +19,21 @@ Come lift up your voices in chorus with mine\
 Come lift up your voices, all grief to refrain\
 For we may or might never all meet here again
 
-> So here's a health to the company and one to my lass\
-> Let's drink and be merry all out of one glass\
-> Let's drink and be merry, all grief to refrain\
-> For we may or might never all meet here again
+> ***So here's a health to the company and one to my lass***\
+> ***Let's drink and be merry all out of one glass***\
+> ***Let's drink and be merry, all grief to refrain***\
+> ***For we may or might never all meet here again***
 
 Here's a health to the wee lass that I love so well\
 For style and for beauty there's none can excel\
 There's a smile on her countenance as she sits upon my knee\
 There is no man in this wide world as happy as me
 
-> So here's a health to the company and one to my lass...
+> ***So here's a health to the company and one to my lass...***
 
 Our ship lies at anchor, she is ready to dock\
 I wish her safe landing without any shock\
 And if ever I should meet you by land or by sea\
 I will always remember your kindness to me
 
-> So here's a health to the company and one to my lass...
+> ***So here's a health to the company and one to my lass...***

--- a/songs/herrings-head-herrings-head.md
+++ b/songs/herrings-head-herrings-head.md
@@ -11,20 +11,20 @@ tags:
   - herring
 date: 2019-03-13T21:32:09.837Z
 ---
-_The herring is the king of the sea,_\
-_The herring is the fish for me._\
-_The herring is the king of the sea,_\
-_Sing fol-the-rol-diddle-ol-day_
+***The herring is the king of the sea,***\
+***The herring is the fish for me.***\
+***The herring is the king of the sea,***\
+***Sing fol-the-rol-diddle-ol-day***
 
 Now what'll I do with the herring’s head?\
 I'll make it into a loaf of bread.\
 I'll make it into a loaf of bread\
 And all sorts of things.
 
-_The herring is the king of the sea,_\
-_The herring is the fish for me._\
-_The herring is the king of the sea,_\
-_Sing fol-the-rol-diddle-ol-day_
+***The herring is the king of the sea,***\
+***The herring is the fish for me.***\
+***The herring is the king of the sea,***\
+***Sing fol-the-rol-diddle-ol-day***
 
 Now what'll I do with me herring's eyes?\
 I'll make 'em into puddings and pies,\
@@ -34,8 +34,8 @@ Herring's eyes and puddings and pies,\
 Herring's heads, loaves of bread\
 And all sorts of things.
 
-_The herring is the king of the sea..._\
-\
+***The herring is the king of the sea...***
+
 Now what'll I do with me herring's fins?\
 I’ll make 'em into needles and pins,\
 I’ll make 'em into needles and pins\
@@ -43,7 +43,7 @@ And all sorts of things.\
 Herring's fins and needles and pins,\
 Herring's eyes and puddings and pies, etc.
 
-_The herring is the king of the sea..._
+***The herring is the king of the sea...***
 
 Now what'll I do with me herring's back?\
 I’ll make it into a laddie called Jack,\
@@ -52,7 +52,7 @@ And all sorts of things.\
 Herring's back, a laddie called Jack,\
 Herring's fins and needles and pins, etc.
 
-_The herring is the king of the sea..._
+***The herring is the king of the sea...***
 
 Now what'll I do with me herring's gills?\
 I’ll make 'em into window sills,\
@@ -61,7 +61,7 @@ And all sorts of things.\
 Herring's gills, window sills,\
 Herring's back, a laddie called Jack, etc.
 
-_The herring is the king of the sea..._
+***The herring is the king of the sea...***
 
 Now what'll I do with me herring's tail?\
 I’ll make it into a barrel of ale,\
@@ -70,4 +70,4 @@ And all sorts of things.\
 Herring's tail, a barrel of ale,\
 Herring's gills, window sills, etc.
 
-_The herring is the king of the sea..._
+***The herring is the king of the sea...***

--- a/songs/jeanne-de-clisson-jeanne-de-clisson.md
+++ b/songs/jeanne-de-clisson-jeanne-de-clisson.md
@@ -41,8 +41,8 @@ As widow and pirate she avenged her dead man
 With sails red as blood, aboard her black ships three
 Lioness of Bretagne, la belle dame sans merci
 
-_With sails red as blood, aboard her black ships three_
-_Lioness of Bretagne, la belle dame sans merci_
+***With sails red as blood, aboard her black ships three***\
+***Lioness of Bretagne, la belle dame sans merci***
 
 Seven centuries ago, in the hundred years’ war
 England and France fought for Brittany’s shores
@@ -59,8 +59,8 @@ So she took her young sons to see their father’s head
 Gazing at his blank eyes, Jeanne yearned for revenge
 And she vowed in that moment, her love to avenge
 
-_With sails red as blood, aboard her black ships three_
-_Lioness of Bretagne, la belle dame sans merci_
+***With sails red as blood, aboard her black ships three***\
+***Lioness of Bretagne, la belle dame sans merci***
 
 She-wolf of the Channel, Lioness of the main
 Jeanne slaughtered French sailors again and again
@@ -72,18 +72,18 @@ She escaped from the wreck, holding her two sons fast
 For five days she rowed, praying for England’s shore
 But her youngest, Guillaume, at last breathed no more
 
-_With sails red as blood, aboard her black ships three_
-_Lioness of Bretagne, la belle dame sans merci_
+***With sails red as blood, aboard her black ships three***\
+***Lioness of Bretagne, la belle dame sans merci***
 
 She cradled his body, adrift on the sea
 Swore she’d bring his sweet brother home to Brittany
 And Jeanne found her way home, and lived peacefully
 Lioness of Bretagne, la belle dame sans merci
 
-_Let me tell you, my friends, of a woman named Jeanne_
-_As widow and pirate she avenged her dead man_
-_With sails red as blood, aboard her black ships three_\
-_Lioness of Bretagne, la belle dame sans merci_
+***Let me tell you, my friends, of a woman named Jeanne***\
+***As widow and pirate she avenged her dead man***\
+***With sails red as blood, aboard her black ships three***\
+***Lioness of Bretagne, la belle dame sans merci***
 
 \---
 

--- a/songs/leaving-of-liverpool-leaving-of-liverpool.md
+++ b/songs/leaving-of-liverpool-leaving-of-liverpool.md
@@ -17,52 +17,52 @@ I'm going far away\
 I'm bound for California\
 but I know that I'll return some day
 
-_So fare thee well, my own true love_\
-_When I return, united we will be_\
-_It's not the leaving of Liverpool that grieves me_ \
-_But my darling when I think of thee_
+***So fare thee well, my own true love***\
+***When I return, united we will be***\
+***It's not the leaving of Liverpool that grieves me*** \
+***But my darling when I think of thee***
 
 Farewell to Prince's Landing Stage \
 River Mersey, fare thee well \
 I am bound for California \
 A place I know right well 
 
-_So fare thee well, my own true love_\
-_When I return, united we will be_\
-I_t's not the leaving of Liverpool that grieves me_ \
-_But my darling when I think of thee_
+***So fare thee well, my own true love***\
+***When I return, united we will be***\
+I***t's not the leaving of Liverpool that grieves me*** \
+***But my darling when I think of thee***
 
 I'm bound for California \
 By the way of stormy Cape Horn \
 And I promise to write you a letter, love \
 When I am homeward bound 
 
-_So fare thee well..._
+***So fare thee well...***
 
 I have signed on a Yankee clipper ship \
 Davy Crockett is her name \
 And Burgess is the captain of her\
 And they say she's a floating shame
 
-_So fare thee well..._
+***So fare thee well...***
 
 I have sailed with Burgess once before \
 And I think I know him well \
 If a man's a seaman, he can get along \
 If not, then he's sure in Hell 
 
-_So fare thee well..._
+***So fare thee well...***
 
 Farewell to lower Frederick Street \
 Ensign Terrace and Park Lane \
 For I think it will be a long, long time \
 Before I see you again 
 
-_So fare thee well..._
+***So fare thee well...***
 
 Oh the sun is on the harbour, love \
 And I wish I could remain \
 For I know it will be a long, long time \
 until I see you again 
 
-_So fare thee well..._
+***So fare thee well...***

--- a/songs/let-the-bulgine-run-let-the-bulgine-run.md
+++ b/songs/let-the-bulgine-run-let-the-bulgine-run.md
@@ -22,17 +22,17 @@ Ah Hey! Ah Ho! Are you most done?\
 Is the Old Wild Cat of the Swallowtail Line!\
 Clear away the track, and let the bulgine run!
 
-> Timme Hey, Rig-a-jig, and a jaunting run!\
-> Ah Hey! Ah Ho! Are you most done?\
-> With Liza Lee all on my knee,\
-> Clear away the track, and let the bulgine run!
+> ***Timme Hey, Rig-a-jig, and a jaunting run!***\
+> ***Ah Hey! Ah Ho! Are you most done?***\
+> ***With Liza Lee all on my knee,***\
+> ***Clear away the track, and let the bulgine run!***
 
 Oh! the Old Wildcat of the Swallowtail Line,\
 Ah Hey! Ah Ho! Are you most done?\
 She's never a day behind her time!\
 Clear away the track, and let the bulgine run!
 
-> Timme Hey, Rig-a-jig, and a jaunting run...
+> ***Timme Hey, Rig-a-jig, and a jaunting run...***
 
 Oh, we're outward bound for New York Town,\
 Them Bowery gals we'll waltz around.

--- a/songs/let-the-bulgine-run-let-the-bulgine-run.md
+++ b/songs/let-the-bulgine-run-let-the-bulgine-run.md
@@ -22,17 +22,17 @@ Ah Hey! Ah Ho! Are you most done?\
 Is the Old Wild Cat of the Swallowtail Line!\
 Clear away the track, and let the bulgine run!
 
->Timme Hey, Rig-a-jig, and a jaunting run!\
->Ah Hey! Ah Ho! Are you most done?\
->With Liza Lee all on my knee,\
->Clear away the track, and let the bulgine run!
+> Timme Hey, Rig-a-jig, and a jaunting run!\
+> Ah Hey! Ah Ho! Are you most done?\
+> With Liza Lee all on my knee,\
+> Clear away the track, and let the bulgine run!
 
 Oh! the Old Wildcat of the Swallowtail Line,\
 Ah Hey! Ah Ho! Are you most done?\
 She's never a day behind her time!\
 Clear away the track, and let the bulgine run!
 
->Timme Hey, Rig-a-jig, and a jaunting run...
+> Timme Hey, Rig-a-jig, and a jaunting run...
 
 Oh, we're outward bound for New York Town,\
 Them Bowery gals we'll waltz around.

--- a/songs/maid-on-the-shore-maid-on-the-shore.md
+++ b/songs/maid-on-the-shore-maid-on-the-shore.md
@@ -9,7 +9,7 @@ tags:
   - song
 date: 2019-03-14T20:37:13.055Z
 description: >-
-  Also known as _The Mermaid_, this ballad hints that the cunning maid on the
+  Also known as ***The Mermaid***, this ballad hints that the cunning maid on the
   shore might be a mermaid or siren, luring men to their doom with her sweet
   voice. We've picked bits and pieces from the many versions of the lyrics.
 ---
@@ -17,20 +17,20 @@ There was a fair maid and she lived all alone\
 She lived all alone on the shore-o\
 No one could she find for to calm her sweet mind\
 As she walked all alone on the shore, shore, shore\
-_As she walked all alone on the shore_
+***As she walked all alone on the shore***
 
 There was a brave captain who sailed a fine ship\
 Let the wind blow high blow low-o\
 "I shall die, I shall die", this young captain did cry\
 "If I can't have that maid on the shore, shore, shore\
-_If I can't have that maid on the shore"_
+***If I can't have that maid on the shore"***
 
 After many persuasions they brought her on board\
 Let the wind blow high blow low-o\
 He invited her down to his cabin below\
 Farewell to all sorrow and care-o\
-_Farewell to all sorrow and care_\
-\
+***Farewell to all sorrow and care***
+
 "Oh thank you, oh thank you," this young girl she cried,\
 “It's just what I've been waiting for-o\
 For I've grown so weary of my maidenhead\
@@ -41,22 +41,22 @@ As I walked all alone on the shore.”
 This captain was weeping for joy-o\
 She sang it so sweetly, so soft and completely\
 She sang captain and sailors to sleep-o\
-_She sang_ _captain and sailors to sleep_
+***She sang captain and sailors to sleep***
 
 She robbed them of silver, she robbed them of gold\
 She robbed them of costly fine fare-o\
 The captain's own sword she used as an oar\
 She rowed her way back to the shore, shore, shore\
-_She rowed her way back to the shore_
+***She rowed her way back to the shore***
 
 Oh the captain was mad and the men, they were sad\
 They were deeply sunk down in despair-o\
 To see her away with her booty so gay\
 For to roam once again on the shore, shore, shore\
-_For to roam once again on the shore_
+***For to roam once again on the shore***
 
 "Now you must be mad and your men must be sad,\
 Oh your men must be deep in despair-o\
 I sang you to sleep and I robbed you of wealth\
 Once again I'm a maid on the shore, shore, shore\
-_Once_ _again I'm a maid on the shore."_
+***Once again I'm a maid on the shore."***

--- a/songs/mingulay-boat-song-mingulay-boat-song.md
+++ b/songs/mingulay-boat-song-mingulay-boat-song.md
@@ -11,37 +11,37 @@ tags:
 date: 2019-03-14T20:47:06.251Z
 description: __
 ---
->Hill-yo-ho, boys! Let her go, boys!\
->Bring her head round, into the weather.\
->Hill-yo-ho, boys! Let her go, boys,\
->Sailing homeward to Mingulay.
+> Hill-yo-ho, boys! Let her go, boys!\
+> Bring her head round, into the weather.\
+> Hill-yo-ho, boys! Let her go, boys,\
+> Sailing homeward to Mingulay.
 
 What care we though, white the Minch is?\
 What care we for wind or weather?\
 Pull her round, boys, every inch is\
 Heading homeward to Mingulay.
 
->Hill-yo-ho, boys! Let her go, boys!\
->Bring her head round, into the weather.\
->Hill-yo-ho, boys! Let her go, boys,\
->Sailing homeward to Mingulay.
+> Hill-yo-ho, boys! Let her go, boys!\
+> Bring her head round, into the weather.\
+> Hill-yo-ho, boys! Let her go, boys,\
+> Sailing homeward to Mingulay.
 
 Wives are waiting at the pier head,\
 looking seaward from the heather;\
 They'll return though, when the sun sets\
 They'll return to Mingulay.
 
->Hill-yo-ho, boys! Let her go, boys!\
->Bring her head round, into the weather.\
->Hill-yo-ho, boys! Let her go, boys,\
->Sailing homeward to Mingulay.
+> Hill-yo-ho, boys! Let her go, boys!\
+> Bring her head round, into the weather.\
+> Hill-yo-ho, boys! Let her go, boys,\
+> Sailing homeward to Mingulay.
 
 Ships return now, heavy laden,\
 Mothers holding bairns a-crying.\
 Let her go boys, and we'll anchor\
 'Ere the sun sets on Mingulay.
 
->Hill-yo-ho, boys! Let her go, boys!\
->Bring her head round, into the weather.\
->Hill-yo-ho, boys! Let her go, boys,\
->Sailing homeward to Mingulay.
+> Hill-yo-ho, boys! Let her go, boys!\
+> Bring her head round, into the weather.\
+> Hill-yo-ho, boys! Let her go, boys,\
+> Sailing homeward to Mingulay.

--- a/songs/mingulay-boat-song-mingulay-boat-song.md
+++ b/songs/mingulay-boat-song-mingulay-boat-song.md
@@ -9,39 +9,39 @@ songLine: 'What care we though, white the Minch is?'
 tags:
   - song
 date: 2019-03-14T20:47:06.251Z
-description: __
+
 ---
-> Hill-yo-ho, boys! Let her go, boys!\
-> Bring her head round, into the weather.\
-> Hill-yo-ho, boys! Let her go, boys,\
-> Sailing homeward to Mingulay.
+> ***Hill-yo-ho, boys! Let her go, boys!***\
+> ***Bring her head round, into the weather.***\
+> ***Hill-yo-ho, boys! Let her go, boys,***\
+> ***Sailing homeward to Mingulay.***
 
 What care we though, white the Minch is?\
 What care we for wind or weather?\
 Pull her round, boys, every inch is\
 Heading homeward to Mingulay.
 
-> Hill-yo-ho, boys! Let her go, boys!\
-> Bring her head round, into the weather.\
-> Hill-yo-ho, boys! Let her go, boys,\
-> Sailing homeward to Mingulay.
+> ***Hill-yo-ho, boys! Let her go, boys!***\
+> ***Bring her head round, into the weather.***\
+> ***Hill-yo-ho, boys! Let her go, boys,***\
+> ***Sailing homeward to Mingulay.***
 
 Wives are waiting at the pier head,\
 looking seaward from the heather;\
 They'll return though, when the sun sets\
 They'll return to Mingulay.
 
-> Hill-yo-ho, boys! Let her go, boys!\
-> Bring her head round, into the weather.\
-> Hill-yo-ho, boys! Let her go, boys,\
-> Sailing homeward to Mingulay.
+> ***Hill-yo-ho, boys! Let her go, boys!***\
+> ***Bring her head round, into the weather.***\
+> ***Hill-yo-ho, boys! Let her go, boys,***\
+> ***Sailing homeward to Mingulay.***
 
 Ships return now, heavy laden,\
 Mothers holding bairns a-crying.\
 Let her go boys, and we'll anchor\
 'Ere the sun sets on Mingulay.
 
-> Hill-yo-ho, boys! Let her go, boys!\
-> Bring her head round, into the weather.\
-> Hill-yo-ho, boys! Let her go, boys,\
-> Sailing homeward to Mingulay.
+> ***Hill-yo-ho, boys! Let her go, boys!***\
+> ***Bring her head round, into the weather.***\
+> ***Hill-yo-ho, boys! Let her go, boys,***\
+> ***Sailing homeward to Mingulay.***

--- a/songs/molly-malone-happy-ending-molly-malone-happy-ending.md
+++ b/songs/molly-malone-happy-ending-molly-malone-happy-ending.md
@@ -19,8 +19,8 @@ I first set my eyes on sweet Molly Malone
 As she wheeled her wheelbarrow, through streets broad and narrow,
 Crying cockles and mussels alive alive-o
 
-> _Alive alive-o, alive alive-o_
-> _Crying cockles and mussels alive alive-o_
+> ***Alive alive-o, alive alive-o***\
+> ***Crying cockles and mussels alive alive-o***
 
 She was a fishmonger
 And sure t'was no wonder
@@ -28,8 +28,8 @@ For so were her father and mother before
 And they both wheeled their barrows, through streets broad and narrow,
 Crying cockles and mussels alive alive-o
 
-> _Alive alive-o, alive alive-o_
-> _Crying cockles and mussels alive alive-o_
+> ***Alive alive-o, alive alive-o***\
+> ***Crying cockles and mussels alive alive-o***
 
 A flower girl named Nancy
 Soon caught Molly's fancy
@@ -37,8 +37,8 @@ And she wooed her with whelks and with muscles so strong
 As they both wheeled their barrows through streets broad and narrow
 They were teasing and laughing through all the night long
 
-> _Through all the night long, through all the night long_
-> _They were teasing and laughing through all the night long_
+> ***Through all the night long, through all the night long***\
+> ***They were teasing and laughing through all the night long***
 
 Love blossomed between them
 I wish you had seen them
@@ -46,8 +46,8 @@ Selling blooms from the meadows and fish from the seas
 As they both wheeled their barrows through streets broad and narrow
 Roses twined in their hair and their joy plain to see
 
-> _Their joy plain to see, their joy plain to see_
-> _Roses twined in their hair and their joy plain to see_
+> ***Their joy plain to see, their joy plain to see***\
+> ***Roses twined in their hair and their joy plain to see***
 
 The finest bouquets
 Were the ones Nancy made
@@ -55,5 +55,5 @@ And the freshest of cockles came from Molly's stall
 So while they were courting they both made their fortune
 And soon said 'we don't need no cockles no more.’
 
-> _No cockles no more, No cockles no more,_
-> _And soon said 'we don't need no cockles no more.’_
+> ***No cockles no more, No cockles no more,***\
+> ***And soon said 'we don't need no cockles no more.’***

--- a/songs/old-zeb-old-zeb.md
+++ b/songs/old-zeb-old-zeb.md
@@ -17,10 +17,10 @@ But I'll see her topsail flyin' when I come down off the way.
 
 Chorus:
 
-> _Rosie, get my Sunday shoes_,
-> _Gertie get my walkin' cane_;
-> _We'll take another walk to see_
-> _Old Alice sail again_.
+> ***Rosie, get my Sunday shoes,***\
+> ***Gertie get my walkin' cane.***\
+> ***We'll take another walk to see***\
+> ***Old Alice sail again.***
 
 Wish I had a nickel for the men I used to know
 Who could load three cords of lumber in half an hour or so.

--- a/songs/old-zeb-old-zeb.md
+++ b/songs/old-zeb-old-zeb.md
@@ -18,9 +18,9 @@ But I'll see her topsail flyin' when I come down off the way.
 Chorus:
 
 > _Rosie, get my Sunday shoes_,
->_Gertie get my walkin' cane_;
->_We'll take another walk to see_
->_Old Alice sail again_.
+> _Gertie get my walkin' cane_;
+> _We'll take another walk to see_
+> _Old Alice sail again_.
 
 Wish I had a nickel for the men I used to know
 Who could load three cords of lumber in half an hour or so.

--- a/songs/paddy-lay-back-paddy-lay-back.md
+++ b/songs/paddy-lay-back-paddy-lay-back.md
@@ -10,45 +10,45 @@ tags:
   - song
 date: 2019-03-14T21:28:31.196Z
 ---
-_Paddy lay back, Take in your slack_\
-_Take a turn around the capstan, heave a-pawl_\
-_About ship's station boys be handy_\
-_For we're off to Valparaiso in the morn_
+***Paddy lay back, Take in your slack***\
+***Take a turn around the capstan, heave a-pawl***\
+***About ship's station boys be handy***\
+***For we're off to Valparaiso in the morn***
 
 That day there was a great demand for sailors\
 For the colonies, for Frisco, and for France\
 So I shipped aboard a Limey bark, 'The Hotspur'\
 And I got paralytic drunk on my advance
 
-_Paddy lay back, Take in your slack_\
-_Take a turn around the capstan, heave a-pawl_\
-_About ship's station boys be handy_\
-_For we're off to Valparaiso in the morn_
+***Paddy lay back, Take in your slack***\
+***Take a turn around the capstan, heave a-pawl***\
+***About ship's station boys be handy***\
+***For we're off to Valparaiso in the morn***
 
 There were Dutchmen, Spaniards, and Russians\
 And jolly boys just across from France\
 Not a one of them could speak a word of English\
 But the answered to the name of 'Month's Advance'
 
-_Paddy lay back, Take in your slack..._
+***Paddy lay back, Take in your slack...***
 
 Now some of the lads they had been drinkin'\
 And meself was heavy on the booze\
 So I sat upon my old sea-chest a -thinkin'\
 That I'd crawl into me bunk and have a snooze
 
-_Paddy lay back, Take in your slack..._
+***Paddy lay back, Take in your slack...***
 
 I woke up in the morning sick and sore\
 For I knew I was outward bound again\
 When I heard a voice bawling at the door\
 Get up ye bastard and listen to your name
 
-_Paddy lay back, Take in your slack..._
+***Paddy lay back, Take in your slack...***
 
 Well I wish I was in the Jolly Sailor\
 Along with Irish navvies drinkin' beer\
 When I thought what jolly lads were sailors\
 And with me flipper I wiped away a tear
 
-_Paddy lay back, Take in your slack..._
+***Paddy lay back, Take in your slack...***

--- a/songs/paddy-west-paddy-west.md
+++ b/songs/paddy-west-paddy-west.md
@@ -22,12 +22,8 @@ He gave me a meal of American hash and he said it was Liverpool scouse,\
 He said, “There's a ship, she's wantin' hands, and on her you must sign,\
 Oh, the mate's a bastard, the bosun's worse, but she will suit you fine.”
 
-> So take off your dungaree jacket, and give yourselves a rest,
->
-> \
->
->
-> And we'll think on them cold nor'westers that we had at Paddy West's.
+> ***So take off your dungaree jacket, and give yourselves a rest,***\
+> ***And we'll think on them cold nor'westers that we had at Paddy West's.***
 
 And it's when the meal was over, boys, the wind began to blow.\
 Paddy sends me to the attic, the main-royal for to stow,\
@@ -51,9 +47,5 @@ And Bejesus but I'm an old sailor man since the day that I were born.
 
 Last chorus:
 
-> So put on yer dungaree jacket and walk up lookin' yer best,
->
-> \
->
->
-> And just tell 'em that you're an old sailor man that's come from Paddy West's.
+> ***So put on yer dungaree jacket and walk up lookin' yer best,***\
+> ***And just tell 'em that you're an old sailor man that's come from Paddy West's.***

--- a/songs/pique-la-baleine-pique-la-baleine.md
+++ b/songs/pique-la-baleine-pique-la-baleine.md
@@ -17,21 +17,16 @@ description: >-
 ---
 Pour retrouver ma douce amie
 
->    Oh mes boués, ouh là ouh là là.
+> ***Oh mes boués, ouh là ouh là là.***
 
 Pour retrouver ma douce amie
 
->    Oh mes boués, ouh là ouh là là.
->
-> Pique la baleine, joli baleinier
->
-> \
->
->
-> Pique la baleine, je veux naviguer.
+> ***Oh mes boués, ouh là ouh là là.***\
+> ***Pique la baleine, joli baleinier***\
+> ***Pique la baleine, je veux naviguer.***
 
-Aux mille mers j'ai navigué.\
-\
+Aux mille mers j'ai navigué.
+
 Des mers du nord aux mers du sud.
 
 Je l'ai retrouvée quand j'm'ai noyé.
@@ -42,21 +37,18 @@ Tous deux ensemble on a pleuré.
 
 En couple à elle, j'm'suis couché.
 
-
-
-English translation:
-
-To find my sweet love,
-
->    Oh my boys, oh la la,
+English translation
+---
 
 To find my sweet love,
 
->    Oh my boys, oh la la,
->
-> Lance the whale, jolly whalerman,
->
-> You lance the whale, I'll steer.
+> ***Oh my boys, oh la la,***
+
+To find my sweet love,
+
+> ***Oh my boys, oh la la,***\
+> ***Lance the whale, jolly whalerman,***\
+> ***You lance the whale, I'll steer.***
 
 I sailed many seas
 

--- a/songs/pirate-chantey-key-and-peele-pirate-chantey-key-and-peele.md
+++ b/songs/pirate-chantey-key-and-peele-pirate-chantey-key-and-peele.md
@@ -26,10 +26,10 @@ So it was off with her we went\
 And we threw her in bed and rested her head\
 And we left, 'cause that's what gentlemen do.
 
-_A woman has a right to a drink or two_\
-_Without worrying about what you will do_\
-_We say "yo, ho!" but we don't say "ho"_\
-_'Cause "ho" is disrespectful, yo_
+***A woman has a right to a drink or two***\
+***Without worrying about what you will do***\
+***We say "yo, ho!" but we don't say "ho"***\
+***'Cause "ho" is disrespectful, yo***
 
 There once was a girl from Leeds\
 Who I heard was good on her knees\
@@ -40,10 +40,10 @@ And my mast began to swell\
 So I laid her down and raised her gown\
 And performed cunnilingus for an hour or so
 
-_Always take care of your lady fair_\
-_'Cause they deserve as much attention down there_\
-_We say "yo, ho!" but we don't say "ho"_\
-_'Cause "ho" is disrespectful, yo_
+***Always take care of your lady fair***\
+***'Cause they deserve as much attention down there***\
+***We say "yo, ho!" but we don't say "ho"***\
+***'Cause "ho" is disrespectful, yo***
 
 I once had a woman so fair\
 Whose womb contained my heir\
@@ -54,10 +54,10 @@ She was working her way through school\
 So I did support when she chose to abort\
 Because it's her body and therefore her choice
 
-_A woman has a right to a drink or two_\
-_Without worrying about what you will do_\
-_We say "yo, ho!" but we don't say "ho"_\
-_'Cause "ho" is disrespectful, yo_
+***A woman has a right to a drink or two***\
+***Without worrying about what you will do***\
+***We say "yo, ho!" but we don't say "ho"***\
+***'Cause "ho" is disrespectful, yo***
 
 No, we don't say "booty" 'less we're talking 'bout gold\
 We don't look at chests 'less it treasure holds\
@@ -75,7 +75,7 @@ Hand in her grave she lay\
 But the scariest part of the story from the start\
 Is I bet you assume the doctor was a man
 
-_Women are doctors too_\
-_And for a fraction of the dubloons_\
-_We say "yo, ho!" but we don't say "ho"_\
-_'Cause "ho" is disrespectful, yo_
+***Women are doctors too***\
+***And for a fraction of the dubloons***\
+***We say "yo, ho!" but we don't say "ho"***\
+***'Cause "ho" is disrespectful, yo***

--- a/songs/pleasant-and-delightful-pleasant-and-delightful.md
+++ b/songs/pleasant-and-delightful-pleasant-and-delightful.md
@@ -15,40 +15,40 @@ It was pleasant and delightful on a midsummer's morn\
 And the green fields and the meadows were all covered in corn;\
 And the blackbirds and thrushes sang on every green spray\
 And the larks they sang melodious at the dawning of the day,\
-_And the larks they sang melodious (3x)_ \
-_at the dawning of the day._
+***And the larks they sang melodious (3x)*** \
+***at the dawning of the day.***
 
 Now a sailor and his true love were a-walking one day.\
 Said the sailor to his true love, “I am bound far away.\
 I'm bound for the East Indies where the loud cannons roar\
 And I'm bound to leave you Nancy, you're the girl that I adore,\
-_And I'm bound to leave you Nancy (3x)_ \
-_you're the girl that I adore.”_
+***And I'm bound to leave you Nancy (3x)*** \
+***you're the girl that I adore.”***
 
 Then the ring from off her finger she instantly drew,\
 Saying, “Take this, dearest William, and my heart will go too.”\
 And as they were embracing tears from her eyes fell,\
 Saying, “May I go along with you?” “Oh no, my love, farewell,”\
-_Saying, “May I go along with you?” (3x)_ \
-_“Oh no, my love, farewell,”_
+***Saying, “May I go along with you?” (3x)*** \
+***“Oh no, my love, farewell,”***
 
 “Fare thee well my dearest Nancy, no longer can I stay,\
 For the topsails are hoisted and the anchors aweigh,\
 And the ship she lies waiting for the fast flowing tide,\
 And if ever I return again, I will make you my bride,\
-_And if ever I return again (3x)_\
-_I will make you my bride.”_
+***And if ever I return again (3x)***\
+***I will make you my bride.”***
 
 Nancy when she saw this says “But he’s the man for me”\
 So she’s taken off her long boots and walked into the sea,\
 And the starfish they were singing, the underwater orchestra did play,\
 And the sharks they played melodeons at the entrance to the bay,\
-_And the sharks they played melodeons (3x)_\
-_at the entrance to the bay._
+***And the sharks they played melodeons (3x)***\
+***at the entrance to the bay.***
 
 Now Billy when he saw this says “There’s the girl for me”\
 So he’s taken off his long boots and jumped into the sea,\
 But he hadn’t washed his tootsies for many is the long day,\
 And his socks smelled so malodorous that she swam the other way,\
-_And his socks smelled so malodorous (3x)_\
-_that she swam the other way._
+***And his socks smelled so malodorous (3x)***\
+***that she swam the other way.***

--- a/songs/row-bullies-row-liverpool-judies-row-bullies-row-liverpool-judies.md
+++ b/songs/row-bullies-row-liverpool-judies-row-bullies-row-liverpool-judies.md
@@ -21,8 +21,8 @@ To live in that country it was my intent;\
 But drinking strong liquor like other damned fools,\
 I soon got transported back to Liverpool.
 
-_And it's row, row bullies row,_\
-_Them Liverpool judies has got us in tow._
+***And it's row, row bullies row,***\
+***Them Liverpool judies has got us in tow.***
 
 I joined the ‘Alaska’ lying out in the bay,\
 A-waiting a fair wind to get under way.\

--- a/songs/row-me-bully-boys-row-row-me-bully-boys-row.md
+++ b/songs/row-me-bully-boys-row-row-me-bully-boys-row.md
@@ -11,21 +11,17 @@ tags:
   - song
 date: 2019-03-11T19:53:57.972Z
 ---
-_And it's row me bully boys, we're in a hurry boys, we got a long way to go_
-_And we'll sing and we'll dance and bid farewell to France_ 
-_And it's row me bully boys row_ 
-
+> ***And it's row me bully boys, we're in a hurry boys, we got a long way to go***\
+> ***And we'll sing and we'll dance and bid farewell to France***\
+> ***And it's row me bully boys row***
 
 I'll sing you a song, it's a song of the sea 
-
-_Row me bully boys row_
+***Row me bully boys row***
 
 I'll sing you a song if you'll sing it with me 
+***And it's row me bully boys row***
 
-_And it's row me bully boys row_
-
-
-_And it's row me bully boys..._
+***And it's row me bully boys...***
 
 
 
@@ -34,8 +30,7 @@ While the first mate is helping the captain aboard
 He looks like a peacock with pistols and sword
 
 
-
-_And it's row me bully boys..._
+***And it's row me bully boys...***
 
 
 
@@ -44,8 +39,7 @@ The captain likes whiskey, the mate he likes rum
 We like em both but we can't get us none 
 
 
-
-_And it's row me bully boys..._
+***And it's row me bully boys...***
 
 
 
@@ -54,5 +48,4 @@ Well come now me lads it is time for to roam
 The old Blue Peter she's calling us home
 
 
-
-_And it's row me bully boys..._
+***And it's row me bully boys...***

--- a/songs/row-on-row-on-row-on-row-on.md
+++ b/songs/row-on-row-on-row-on-row-on.md
@@ -18,10 +18,10 @@ There's thunder in the wind.
 Row on, row on and homeward hie,
 Nae give one look behind.
 
-> Row on, row on, another day
-> May shine with brighter light.
-> Ply, ply the oars and haul away,
-> There's dawn beyond the night.
+> ***Row on, row on, another day***\
+> ***May shine with brighter light.***\
+> ***Ply, ply the oars and haul away,***\
+> ***There's dawn beyond the night.***
 
 Bear where thou goest these words of love,
 Say all that words can say.

--- a/songs/run-the-riggin-again-run-the-riggin-again.md
+++ b/songs/run-the-riggin-again-run-the-riggin-again.md
@@ -14,40 +14,40 @@ When I was a fair maid about seventeen
 I enlisted in the Navy for to serve the queen
 I enlisted in the Navy a sailor for to stand
 For to hear the cannons rattling and the music so grand
-> The music so grand, the music so grand
-> For to hear the cannons rattling and the music so grand
+> ***The music so grand, the music so grand***\
+> ***For to hear the cannons rattling and the music so grand***
 
 The officer that enlisted me was a fine and handsome man
 He said You'll make a sailor so come along my lad
 My waist being tall and slender my fingers long and thin
 And the minute that they learned me I soon exceeded them
-> I soon exceeded them, I soon exceeded them
-> Oh the minute that they learned me I soon exceeded them
+> ***I soon exceeded them, I soon exceeded them***\
+> ***Oh the minute that they learned me I soon exceeded them***
 
 Well they sent me to my bunk and they sent me to my bed
 To lies with the sailors I never was afraid
 But taking off my bluecoat it often made me smile
 For to think I laid with a thousand men and a maiden all the while
-> A maiden all the while, a maiden all the while
-> For to think I laid with a thousand men and a maiden all the while
+> ***A maiden all the while, a maiden all the while***\
+> ***For to think I laid with a thousand men and a maiden all the while***
 
 Well they sent me up to London for to guard the tower
 And surely might I been there till my very dying hour
 But a lady fell in love with me so I told her I was a maid
 Well she went up to my captain and my secret she betrayed
-> My secret she betrayed, my secret she betrayed
-> She went up to my captain and my secret she betrayed
+> ***My secret she betrayed, my secret she betrayed***\
+> ***She went up to my captain and my secret she betrayed***
 
 The captain he came up to me and he asked if it was so
 I dare not I dare not I dare not say no
 A pity we should lose you such a sailor lad you made
 It's a pity we should lose you such a handsome young maid
-> A handsome young maid, a handsome young maid
-> It's a pity we should lose you such a handsome young maid
+> ***A handsome young maid, a handsome young maid***\
+> ***It's a pity we should lose you such a handsome young maid***
 
 So fare thee well my captain you've been so kind to me
 And fare thee well my shipmates I must depart from thee
 But if the Navy ever needs a lad a sailor I'll remain 
 I'll take off my hat and feathers and I'll run the rigging again
-> I'll run the rigging again, I'll run the rigging again
-> I'll take off my hat and feathers and I'll run the rigging again
+> ***I'll run the rigging again, I'll run the rigging again***\
+> ***I'll take off my hat and feathers and I'll run the rigging again***

--- a/songs/run-the-riggin-again-run-the-riggin-again.md
+++ b/songs/run-the-riggin-again-run-the-riggin-again.md
@@ -14,40 +14,40 @@ When I was a fair maid about seventeen
 I enlisted in the Navy for to serve the queen
 I enlisted in the Navy a sailor for to stand
 For to hear the cannons rattling and the music so grand
->The music so grand, the music so grand
->For to hear the cannons rattling and the music so grand
+> The music so grand, the music so grand
+> For to hear the cannons rattling and the music so grand
 
 The officer that enlisted me was a fine and handsome man
 He said You'll make a sailor so come along my lad
 My waist being tall and slender my fingers long and thin
 And the minute that they learned me I soon exceeded them
->I soon exceeded them, I soon exceeded them
->Oh the minute that they learned me I soon exceeded them
+> I soon exceeded them, I soon exceeded them
+> Oh the minute that they learned me I soon exceeded them
 
 Well they sent me to my bunk and they sent me to my bed
 To lies with the sailors I never was afraid
 But taking off my bluecoat it often made me smile
 For to think I laid with a thousand men and a maiden all the while
->A maiden all the while, a maiden all the while
->For to think I laid with a thousand men and a maiden all the while
+> A maiden all the while, a maiden all the while
+> For to think I laid with a thousand men and a maiden all the while
 
 Well they sent me up to London for to guard the tower
 And surely might I been there till my very dying hour
 But a lady fell in love with me so I told her I was a maid
 Well she went up to my captain and my secret she betrayed
->My secret she betrayed, my secret she betrayed
->She went up to my captain and my secret she betrayed
+> My secret she betrayed, my secret she betrayed
+> She went up to my captain and my secret she betrayed
 
 The captain he came up to me and he asked if it was so
 I dare not I dare not I dare not say no
 A pity we should lose you such a sailor lad you made
 It's a pity we should lose you such a handsome young maid
->A handsome young maid, a handsome young maid
->It's a pity we should lose you such a handsome young maid
+> A handsome young maid, a handsome young maid
+> It's a pity we should lose you such a handsome young maid
 
 So fare thee well my captain you've been so kind to me
 And fare thee well my shipmates I must depart from thee
 But if the Navy ever needs a lad a sailor I'll remain 
 I'll take off my hat and feathers and I'll run the rigging again
->I'll run the rigging again, I'll run the rigging again
->I'll take off my hat and feathers and I'll run the rigging again
+> I'll run the rigging again, I'll run the rigging again
+> I'll take off my hat and feathers and I'll run the rigging again

--- a/songs/salt-liberty-ballad-of-mary-lacy.md
+++ b/songs/salt-liberty-ballad-of-mary-lacy.md
@@ -21,32 +21,32 @@ And the name I was given was Mary
 I learned a girl’s duties and all that they meant
 To stay pure, hold my tongue, guard my beauty
 
-_But I longed for the sea
+***But I longed for the sea
 Salt liberty
-And the name that I chose was William_
+And the name that I chose was William***
 
 When I could I climbed trees and lay in the sun
 Up aloft where the wind shakes the boughs
 But for maids there is always hard work to be done
 As the horses are yoked to the plough
 
-_But I longed for the sea
+***But I longed for the sea
 Salt liberty
-And the name that I chose was William_
+And the name that I chose was William***
 
 At the age of nineteen, I first broke my heart
 My sweetheart so fair looked right through me
 It was then I resolved that I’d make a new start
 Far away in some place no one knew me
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 On the first day of May, 1759
 As the sun rose I stole from my chamber
 With a pack of men’s clothes that I’d stole from the line
 I strode out, little minding the danger
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 As I roved out I scattered my old clothes behind
 Leaving stockings in ditches and hedgerows
@@ -58,7 +58,7 @@ And Lacy my old maiden name
 I chose Chandler, my mother’s surname as a child
 And my father’s first name which was William.
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 I made for the dockyard in old Chatham town
 And a hawk-eyed recruiter soon spied me
@@ -70,14 +70,14 @@ The Sandwich, a ninety gun ship of the line
 My master was Baker, the carpenter there
 A foul-tempered drunk though when sober quite kind
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 As I lived as a man I’d my corner to fight
 One knave William Severy would taunt me
 I squared up for a match with him one stormy night
 Though he near dashed my brains out I never gave in
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 When the seven years war ended in ‘63
 My joy was too great to contain
@@ -89,7 +89,7 @@ I learned to coax boats from the lumber
 And found love in the arms of sweet Sarah Chase
 And coaxed from her kisses so tender
 
-_But I longed for the sea..._
+***But I longed for the sea...***
 
 After seven long years I was shipwright made free
 But my joints were seized up with the rheumatism
@@ -101,4 +101,4 @@ And in Deptford I married and lived out my days
 Six children I bore and four children I lost
 And in 1801 I was laid in my grave
 
-_But I longed for the sea…_
+***But I longed for the sea…***

--- a/songs/soon-may-the-wellerman-come-soon-may-the-wellerman-come.md
+++ b/songs/soon-may-the-wellerman-come-soon-may-the-wellerman-come.md
@@ -24,42 +24,40 @@ The name of the ship was the Billy of Tea \
 The winds blew up, her bow dipped down, \
 O blow, my bully boys, blow.
 
-_Soon may the Wellerman come_ \
-_And bring us sugar and tea and rum._ \
-_One day, when the tonguin' is done,_ \
-_We'll take our leave and go._
+***Soon may the Wellerman come*** \
+***And bring us sugar and tea and rum.*** \
+***One day, when the tonguin' is done,*** \
+***We'll take our leave and go.***
 
 She had not been two weeks from shore \
 When down on her a right whale bore. \
 The captain called all hands and swore \
 He'd take that whale in tow. 
 
-_Soon may the Wellerman come..._
+***Soon may the Wellerman come...***
 
 Before the boat had hit the water \
 The whale's tail came up and caught her. \
 All hands to the side, harpooned and fought her \
 When she dived down below. 
 
-_Soon may the Wellerman come..._
+***Soon may the Wellerman come...***
 
 No line was cut, no whale was freed; \
 The Captain's mind was not of greed, \
 But he belonged to the whaleman's creed; \
 She took the ship in tow. 
 
-_Soon may the Wellerman come..._
+***Soon may the Wellerman come...***
 
 For forty days, or even more, \
 The line went slack, then tight once more. \
 All boats were lost (there were only four) \
 But still the whale did go. 
 
-_Soon may the Wellerman come..._
+***Soon may the Wellerman come...***
 
 As far as I've heard, the fight's still on; \
 The line's not cut and the whale's not gone. \
 The Wellerman makes his regular call \
 To encourage the Captain, crew, and all.
-
-__

--- a/songs/the-ballad-of-anne-bonny-the-ballad-of-anne-bonny.md
+++ b/songs/the-ballad-of-anne-bonny-the-ballad-of-anne-bonny.md
@@ -26,10 +26,10 @@ I know it sounds absurd\
 She ran the brig to Martinique\
 Past that we haven't heard
 
->_She'll steal the pennies off your eyes before your corpse is cold_\
->_And wear your guts as garters before your shirt's been sold_\
->_But generous to a fault, they say she'd give away her coat_\
->_And if you're caught asleep on watch, she'll slit your bloody throat_
+> _She'll steal the pennies off your eyes before your corpse is cold_\
+> _And wear your guts as garters before your shirt's been sold_\
+> _But generous to a fault, they say she'd give away her coat_\
+> _And if you're caught asleep on watch, she'll slit your bloody throat_
 
 The Spanish were full terrified\
 She'd cleaned off all their decks\

--- a/songs/the-ballad-of-anne-bonny-the-ballad-of-anne-bonny.md
+++ b/songs/the-ballad-of-anne-bonny-the-ballad-of-anne-bonny.md
@@ -26,10 +26,10 @@ I know it sounds absurd\
 She ran the brig to Martinique\
 Past that we haven't heard
 
-> _She'll steal the pennies off your eyes before your corpse is cold_\
-> _And wear your guts as garters before your shirt's been sold_\
-> _But generous to a fault, they say she'd give away her coat_\
-> _And if you're caught asleep on watch, she'll slit your bloody throat_
+> ***She'll steal the pennies off your eyes before your corpse is cold***\
+> ***And wear your guts as garters before your shirt's been sold***\
+> ***But generous to a fault, they say she'd give away her coat***\
+> ***And if you're caught asleep on watch, she'll slit your bloody throat***
 
 The Spanish were full terrified\
 She'd cleaned off all their decks\
@@ -40,7 +40,7 @@ For fear she'd come in view\
 The pirate queen would pick them clean\
 Before they'd quite hove to\
 
-> _She'll steal the pennies off your eyes..._
+> ***She'll steal the pennies off your eyes...***
 
 Anne Bonny is a terror\
 She'll swing you from the yards\
@@ -51,4 +51,4 @@ And generous with her charms\
 Vanquished men have 'riz' again\
 For one night in her arms
 
-> _She'll steal the pennies off your eyes..._
+> ***She'll steal the pennies off your eyes...***

--- a/songs/the-blyth-sailors-farewell-the-blyth-sailors-farewell.md
+++ b/songs/the-blyth-sailors-farewell-the-blyth-sailors-farewell.md
@@ -20,28 +20,28 @@ From bonnie Blyth Harbour leaving friends old and new\
 To parents and wives and sweethearts a-dear\
 Let us join in one chorus with hearty good cheer
 
->_Then trusting our vessel to captain and mate_\
->_For health and for fortune we're subject to fate_\
->_But we'll dare even death on the wide-ranging main_\
->_And return to Blyth Harbour again and again_
+> _Then trusting our vessel to captain and mate_\
+> _For health and for fortune we're subject to fate_\
+> _But we'll dare even death on the wide-ranging main_\
+> _And return to Blyth Harbour again and again_
 
 They'll leave home contented quite Blyth-some and gay\
 Fighting the ocean so far far away\
 Seeking for cargo in many a strange shore\
 Then turn her around for Blyth Harbour once more
 
->_Then trusting our vessel to captain and mate_
+> _Then trusting our vessel to captain and mate_
 
 We're loaded with coal to Holland we're bound\
 Then away on down channel where trade can be found\
 Calling ports there from France through to Spain\
 With a westerly breeze turning homeward again
 
->_Then trusting our vessel to captain and mate_
+> _Then trusting our vessel to captain and mate_
 
 Then heave her home boys we are now homeward bound\
 With a valuable cargo no matter where found\
 With fair wind and weather we'll soon be ashore\
 Safe-anchored in bonnie Blyth Harbour once more
 
->_Then trusting our vessel to captain and mate_
+> _Then trusting our vessel to captain and mate_

--- a/songs/the-blyth-sailors-farewell-the-blyth-sailors-farewell.md
+++ b/songs/the-blyth-sailors-farewell-the-blyth-sailors-farewell.md
@@ -20,28 +20,28 @@ From bonnie Blyth Harbour leaving friends old and new\
 To parents and wives and sweethearts a-dear\
 Let us join in one chorus with hearty good cheer
 
-> _Then trusting our vessel to captain and mate_\
-> _For health and for fortune we're subject to fate_\
-> _But we'll dare even death on the wide-ranging main_\
-> _And return to Blyth Harbour again and again_
+> ***Then trusting our vessel to captain and mate***\
+> ***For health and for fortune we're subject to fate***\
+> ***But we'll dare even death on the wide-ranging main***\
+> ***And return to Blyth Harbour again and again***
 
 They'll leave home contented quite Blyth-some and gay\
 Fighting the ocean so far far away\
 Seeking for cargo in many a strange shore\
 Then turn her around for Blyth Harbour once more
 
-> _Then trusting our vessel to captain and mate_
+> ***Then trusting our vessel to captain and mate***
 
 We're loaded with coal to Holland we're bound\
 Then away on down channel where trade can be found\
 Calling ports there from France through to Spain\
 With a westerly breeze turning homeward again
 
-> _Then trusting our vessel to captain and mate_
+> ***Then trusting our vessel to captain and mate***
 
 Then heave her home boys we are now homeward bound\
 With a valuable cargo no matter where found\
 With fair wind and weather we'll soon be ashore\
 Safe-anchored in bonnie Blyth Harbour once more
 
-> _Then trusting our vessel to captain and mate_
+> ***Then trusting our vessel to captain and mate***

--- a/songs/the-fishermans-wife-the-fishermans-wife.md
+++ b/songs/the-fishermans-wife-the-fishermans-wife.md
@@ -75,8 +75,8 @@ loup = flip-flop
 qued = could
 bairn = child
 
-An Aberdeen song, still current.  See Sheila Douglas, _The Sang's the
-Thing_. (Polygon, Edinburgh, 1992)  Sung by "The Shipping News" at the
+An Aberdeen song, still current.  See Sheila Douglas, ***The Sang's the
+Thing***. (Polygon, Edinburgh, 1992)  Sung by "The Shipping News" at the
 Mystic Sea Music Festival, June 1998. AJS
 AJS
 APR99

--- a/songs/the-king-of-the-southern-sea-the-king-of-the-southern-sea.md
+++ b/songs/the-king-of-the-southern-sea-the-king-of-the-southern-sea.md
@@ -36,13 +36,10 @@ And he scatters the spray in his boisterous play,
 
 As he dashes the King of the deep.
 
-> Oh, the rare old whale, 'mid storm and gale,
->
-> In his ocean home will be;
->
-> A giant in might, where might is right,
->
-> And king of the boundless sea.
+> ***Oh, the rare old whale, 'mid storm and gale,***\
+> ***In his ocean home will be;***\
+> ***A giant in might, where might is right,***\
+> ***And king of the boundless sea.***
 
 A wond'rous tale could the rare old whale
 
@@ -60,7 +57,7 @@ Shaking the tide from his glassy side,
 
 And sporting with ocean and wreck.
 
-> Then the rare old whale, &c.
+> ***Then the rare old whale, &c.***
 
 Then the whale shall be still dear to me,
 
@@ -78,4 +75,4 @@ Then we'll on land go hand in hand,
 
 To hall him the Ocean King,
 
-> Oh, the rare old whale, &c.
+> ***Oh, the rare old whale, &c.***

--- a/songs/the-last-bristolian-pirate-the-last-bristolian-pirate.md
+++ b/songs/the-last-bristolian-pirate-the-last-bristolian-pirate.md
@@ -24,65 +24,65 @@ description: >-
   2013 CD [Bones in the
   Ocean](https://thelongestjohns.bandcamp.com/album/bones-in-the-ocean).
 ---
-I used to be a farmer, and I made a living fine,
-I had a little stretch of land along the western line
-But times were hard and though I tried, the money wasn't there
-And the bankers came and took my land and told me "fair is fair"\
+I used to be a farmer, and I made a living fine,\
+I had a little stretch of land along the western line\
+But times were hard and though I tried, the money wasn't there\
+And the bankers came and took my land and told me "fair is fair"
 
-I looked for every kind of job, the answer always no
-"Hire you now?" they'd always laugh, "we just let twenty go!"
-The government, the promised me a measly little sum
+I looked for every kind of job, the answer always no\
+"Hire you now?" they'd always laugh, "we just let twenty go!"\
+The government, the promised me a measly little sum\
 But I've got too much pride to end up just another bum.
 
-Then I thought, who gives a damn if all the jobs are gone?
+Then I thought, who gives a damn if all the jobs are gone?\
 I'm gonna be a PIRATE on the river Severn!
 
-_And it's a heave! ho! hi! ho! Comin' down the plains_
-_Stealin' wheat and barley and all the other grains_
-_It's a ho! hey! hi! hey! Farmers bar yer doors_
-_When you see the Jolly Roger on the Severn's mighty shores_
+***And it's a heave! ho! hi! ho! Comin' down the plains***\
+***Stealin' wheat and barley and all the other grains***\
+***It's a ho! hey! hi! hey! Farmers bar yer doors***\
+***When you see the Jolly Roger on the Severn's mighty shores***
 
-Well, you'd think the local farmers would know that I'm at large
-But just the other day I found an unprotected barge
-I snuck up right behind them and they were none the wiser,
+Well, you'd think the local farmers would know that I'm at large\
+But just the other day I found an unprotected barge\
+I snuck up right behind them and they were none the wiser,\
 I rammed their ship and sank it and I stole their fertilizer!
 
-A bridge outside of Chepstow spans the mighty river
-Farmers cross in so much fear their stomachs are a'quiver
-Cause they know that Tractor Jack is hidin' in the bay
+A bridge outside of Chepstow spans the mighty river\
+Farmers cross in so much fear their stomachs are a'quiver\
+Cause they know that Tractor Jack is hidin' in the bay\
 I'll jump the bridge and knock them cold and sail off with their hay!
 
-_And it's a heave! ho! hi! ho! Comin' down the plains_
-_Stealin' wheat and barley and all the other grains_
-_It's a ho! hey! hi! hey! Farmers bar yer doors_
-_When you see the Jolly Roger on the Severn's mighty shores_
+***And it's a heave! ho! hi! ho! Comin' down the plains***\
+***Stealin' wheat and barley and all the other grains***\
+***It's a ho! hey! hi! hey! Farmers bar yer doors***\
+***When you see the Jolly Roger on the Severn's mighty shores***
 
-Well, PC Bob he chased me, he was always at my throat
-He followed on the shoreline cause he didn't own a boat
-But cutbacks were a'coming and the Mountie lost his job
+Well, PC Bob he chased me, he was always at my throat\
+He followed on the shoreline cause he didn't own a boat\
+But cutbacks were a'coming and the Mountie lost his job\
 So now he's sailing with us, and we call him Salty Bob!\
 
-A swingin' sword, a skull and bones and pleasant company
-I never pay my income tax and screw the VAT (SCREW IT!!)
-Sailin down to Thornbury, the terror of the seas
+A swingin' sword, a skull and bones and pleasant company\
+I never pay my income tax and screw the VAT (SCREW IT!!)\
+Sailin down to Thornbury, the terror of the seas\
 If you wanna get to Tesco boys, you gotta get by me!
 
-_And it's a heave! ho! hi! ho! Comin' down the plains_
-_Stealin' wheat and barley and all the other grains_
-_It's a ho! hey! hi! hey! Farmers bar yer doors_
-_When you see the Jolly Roger on the Severn's mighty shores_
+***And it's a heave! ho! hi! ho! Comin' down the plains***\
+***Stealin' wheat and barley and all the other grains***\
+***It's a ho! hey! hi! hey! Farmers bar yer doors***\
+***When you see the Jolly Roger on the Severn's mighty shores***
 
-Well, Pirate life's appealing but you just don't find it here,
-I hear that up in Yorkshire there's a band of buccaneers
-They roam around the Yorkshire Dales from Yarm to Brierly
+Well, Pirate life's appealing but you just don't find it here,\
+I hear that up in Yorkshire there's a band of buccaneers\
+They roam around the Yorkshire Dales from Yarm to Brierly\
 And you're gonna lose your flat cap if you have to pass their way!
 
-Well, winter is a'comin' and a chill is in the breeze
-My pirate days are over once the river starts to freeze
-I'll be back in springtime but now I have to fly
+Well, winter is a'comin' and a chill is in the breeze\
+My pirate days are over once the river starts to freeze\
+I'll be back in springtime but now I have to fly\
 I hear there's lots of plunderin' down in the Isle of Wight!
 
-_And it's a heave! ho! hi! ho! Comin' down the plains_
-_Stealin' wheat and barley and all the other grains_
-_It's a ho! hey! hi! hey! Farmers bar yer doors_
-_When you see the Jolly Roger on the Severn's mighty shores_
+***And it's a heave! ho! hi! ho! Comin' down the plains***\
+***Stealin' wheat and barley and all the other grains***\
+***It's a ho! hey! hi! hey! Farmers bar yer doors***\
+***When you see the Jolly Roger on the Severn's mighty shores***

--- a/songs/the-mariners-dream-the-mariners-dream.md
+++ b/songs/the-mariners-dream-the-mariners-dream.md
@@ -21,10 +21,10 @@ His hammock swang loose in the wind\
 But watch-worn weary, his cares slipped away\
 And sweet dreams rose into his mind
 
-_My sailor boy, I wish you sweet sleep_\
-_As you’re rocked by the waves so deep_\
-_My sailor boy come safely home_\
-_Come safely home to me_
+***My sailor boy, I wish you sweet sleep***\
+***As you’re rocked by the waves so deep***\
+***My sailor boy come safely home***\
+***Come safely home to me***
 
 He dreamt of his childhood home far away\
 His parents’ fond smiles of delight\

--- a/songs/twiddles-twiddles.md
+++ b/songs/twiddles-twiddles.md
@@ -22,35 +22,35 @@ What about the women who are up and left alone\
 Do you think they sit and twiddle thumbs until their men come home\
 Ha! There's other things to twiddle when a girl's left on her own.
 
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay*\
-> *Well it's oftentimes a man will leave you broken with dismay*\
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay*\
-> *But there's other things to twiddle when your man has sailed away.*
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay***\
+> ***Well it's oftentimes a man will leave you broken with dismay***\
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay***\
+> ***But there's other things to twiddle when your man has sailed away.***
 
 Well, I remember Nancy, she was young and she was gay\
 She won the heart of Captain Dan until he sailed away\
 He left her high and dry with just a kiss upon the chin\
 But as his ship went sailing out, another ship sailed in.
 
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*\
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...***\
 
 And then there was Lucinda Brown, as fair as any maid\
 Her true love went a voyaging, a sailorman by trade\
 "Oh, keep the fire burning, love," those are the words he spoke\
 So she found herself another man to keep that fire stoked.
 
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...***
 
 Lucy Jeffers' man came back and knocked upon the door\
 She was as glad to see him as she'd ever been before\
 He left her sleeping in the bed, but Lucy didn't care\
 Cuz the poor guy in the closet sure could use a little air.\
 
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...***
 
 Oh you hear a lot of stories 'bout the sailors and their sport\
 About how every sailor has a girl in every port\
 But if you added two and two, you'd figure out right quick\
 It's just because the girls all have a lad on every ship.
 
-> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> ***And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...***

--- a/songs/twiddles-twiddles.md
+++ b/songs/twiddles-twiddles.md
@@ -32,25 +32,25 @@ She won the heart of Captain Dan until he sailed away\
 He left her high and dry with just a kiss upon the chin\
 But as his ship went sailing out, another ship sailed in.
 
->*And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*\
+> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*\
 
 And then there was Lucinda Brown, as fair as any maid\
 Her true love went a voyaging, a sailorman by trade\
 "Oh, keep the fire burning, love," those are the words he spoke\
 So she found herself another man to keep that fire stoked.
 
->*And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
 
 Lucy Jeffers' man came back and knocked upon the door\
 She was as glad to see him as she'd ever been before\
 He left her sleeping in the bed, but Lucy didn't care\
 Cuz the poor guy in the closet sure could use a little air.\
 
->*And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
 
 Oh you hear a lot of stories 'bout the sailors and their sport\
 About how every sailor has a girl in every port\
 But if you added two and two, you'd figure out right quick\
 It's just because the girls all have a lad on every ship.
 
->*And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*
+> *And it's twiddly-i dee-i dee-i, twiddly-i dee-ay...*

--- a/songs/what-shall-we-do-with-the-patriarchy-what-shall-we-do-with-the-patriarchy.md
+++ b/songs/what-shall-we-do-with-the-patriarchy-what-shall-we-do-with-the-patriarchy.md
@@ -18,23 +18,23 @@ What shall we do with the Patriarchy?\
 Let’s do away with the whole malarky\
 Smash the Patriarchy!
 
-_Hooray and up she rises_\
-_Hooray and up she rises_\
-_Hooray and up she rises_\
-_Early in the morning_
+***Hooray and up she rises***\
+***Hooray and up she rises***\
+***Hooray and up she rises***\
+***Early in the morning***
 
 A fair day’s wage for a fair day’s work x3\
 Smash the Patriarchy!
 
-_Hooray and up she rises_\
-_Hooray and up she rises_\
-_Hooray and up she rises_\
-_Early in the morning_
+***Hooray and up she rises***\
+***Hooray and up she rises***\
+***Hooray and up she rises***\
+***Early in the morning***
 
 Girls just wanna have fundamental human rights x3\
 Smash the Patriarchy!
 
-_Hooray and up she rises..._
+***Hooray and up she rises...***
 
 End circumcision and FGM x3\
 Smash the Patriarchy!

--- a/songs/wild-goose-shanty-wild-goose-shanty.md
+++ b/songs/wild-goose-shanty-wild-goose-shanty.md
@@ -12,31 +12,31 @@ date: 2019-03-14T21:05:57.570Z
 description: ''
 ---
 Did you ever see the wild goose sailing on the ocean\
-_Ranzo my boys oh Ranzo Ray_\
+***Ranzo my boys oh Ranzo Ray***\
 They're just like them pretty girls when they get the notion\
 Ranzo my boys oh Ranzo Ray
 
 Chorus:
 
-_Ranzo you'll rue the day_\
-_As the wild goose sails away_
+***Ranzo you'll rue the day***\
+***As the wild goose sails away***
 
 As I was walking one evening by the river\
-_Ranzo my boys oh Ranzo Ray_\
+***Ranzo my boys oh Ranzo Ray***\
 I met with a pretty girl my heart it was a quiver\
-_Ranzo my boys oh Ranzo Ray_
+***Ranzo my boys oh Ranzo Ray***
 
-_(Chorus x 2)_
+***(Chorus x 2)***
 
 I said how are you doing this morning\
-_Ranzo my boys oh Ranzo Ray_\
+***Ranzo my boys oh Ranzo Ray***\
 She said none the better for the seeing of you\
-_Ranzo my boys oh Ranzo Ray_
+***Ranzo my boys oh Ranzo Ray***
 
-_(Chorus x 2)_
+***(Chorus x 2)***
 
 You broke my heart oh you broke it full sore\
-_Ranzo my boys oh Ranzo Ray_\
+***Ranzo my boys oh Ranzo Ray***\
 If I sail like the wild goose\
 You'll break it no more\
-_Ranzo my boys oh Ranzo Ray_
+***Ranzo my boys oh Ranzo Ray***

--- a/songs/william-taylor-william-taylor.md
+++ b/songs/william-taylor-william-taylor.md
@@ -22,7 +22,7 @@ Met him on the king's highway
 As he went for to be married
 Pressed he was and sent away
 
->Folleri-de-dom, de- daerai diddero
+> Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
@@ -36,7 +36,7 @@ She amongst the rest did fight
 The wind blew off her silver buttons
 Her breasts were bared all snowy white
 
->Folleri-de-dom, de- daerai diddero
+> Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
@@ -50,7 +50,7 @@ Early at the break of day.
 There you'll find young William Taylor
 Walking with his lady gay.
 
->Folleri-de-dom, de- daerai diddero
+> Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae

--- a/songs/william-taylor-william-taylor.md
+++ b/songs/william-taylor-william-taylor.md
@@ -22,7 +22,7 @@ Met him on the king's highway
 As he went for to be married
 Pressed he was and sent away
 
-> Folleri-de-dom, de- daerai diddero
+> ***Folleri-de-dom, de- daerai diddero***
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
@@ -36,7 +36,7 @@ She amongst the rest did fight
 The wind blew off her silver buttons
 Her breasts were bared all snowy white
 
-> Folleri-de-dom, de- daerai diddero
+> ***Folleri-de-dom, de- daerai diddero***
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae
@@ -50,7 +50,7 @@ Early at the break of day.
 There you'll find young William Taylor
 Walking with his lady gay.
 
-> Folleri-de-dom, de- daerai diddero
+> ***Folleri-de-dom, de- daerai diddero***
 Folleri-de-dom, domme daerai dae
 Folleri-de-dom, de- daerai diddero
 Folleri-de-dom, domme daerai dae

--- a/songs/windy-old-weather-windy-old-weather.md
+++ b/songs/windy-old-weather-windy-old-weather.md
@@ -12,7 +12,7 @@ tags:
 date: 2019-11-11T20:02:47.381Z
 description: >-
   Transcribed from a recording of Joe Latter, this song appears on some
-  broadsides as _The Fishes’ Lamentation_ and seems to have survived as a
+  broadsides as ***The Fishes’ Lamentation*** and seems to have survived as a
   sailor’s chantey or fisherman’s song. Whall (1910), Colcord (1938) and Hugill
   (1964) include it in their chantey books. It was also recorded from Bob
   Roberts on board his Thames barge, The Cambria and appears in the Newfoundland
@@ -22,16 +22,8 @@ As we were a fishing off Happisburgh Light,\
 Shooting and trawling and hauling all night.\
 It was…
 
-> Windy old weather, stormy old weather.
->
-> \
->
->
-> When the wind blows we all pull together
->
->
->
->
+> ***Windy old weather, stormy old weather.***\
+> ***When the wind blows we all pull together***
 
 We first saw the herring, the queen of the sea.\
 She says ‘you old skipper you’ll never catch me’\

--- a/songs/wreck-of-the-dandenong-wreck-of-the-dandenong.md
+++ b/songs/wreck-of-the-dandenong-wreck-of-the-dandenong.md
@@ -24,10 +24,10 @@ Through the storm she cleaved her way\
 Well it's sad to relate her terrible fate\
 Was just off Jervis bay
 
-> And I dream of you, I dream of sleep\
-> I dream of bein' warm\
-> But through the night I have to sail\
-> To brave this raging storm
+> ***And I dream of you, I dream of sleep***\
+> ***I dream of bein' warm***\
+> ***But through the night I have to sail***\
+> ***To brave this raging storm***
 
 While steering through the briny waves,\
 A propelling shaft gave way\
@@ -47,10 +47,10 @@ In spite of land or wave\
 They did all they could as sailors would\
 Those precious lives to save
 
-> And I dream of you, I dream of sleep\
-> I dream of bein' warm\
-> And pray the sea will leave me be\
-> To see another dawn
+> ***And I dream of you, I dream of sleep***\
+> ***I dream of bein' warm***\
+> ***And pray the sea will leave me be***\
+> ***To see another dawn***
 
 Now some in boats they tried to reach\
 That kind and friendly barque\
@@ -61,12 +61,12 @@ When the storm increased on strong\
 And the rest now sleep in the briny deep\
 Along with the Dandenong
 
-> And I dream of you, I dream of sleep\
-> I dream of comin' home\
-> But a mile of water buries me\
-> Beneath this ragin' foam
+> ***And I dream of you, I dream of sleep***\
+> ***I dream of comin' home***\
+> ***But a mile of water buries me***\
+> ***Beneath this ragin' foam***
 >
-> And I dream of you, I dream of sleep\
-> I dream of bein' warm\
-> But through the night I have to sail\
-> To brave this raging storm
+> ***And I dream of you, I dream of sleep***\
+> ***I dream of bein' warm***\
+> ***But through the night I have to sail***\
+> ***To brave this raging storm***


### PR DESCRIPTION
This makes every chorus (whether intented or mid-verse) appear as bold & italic, using the `***` syntax. 
In the course of applying this (which was mostly automated via regex), I manually fixed some clearly odd formatting errors in some songs.

Also the chorus blocks should now have a space after the `>`