### PR TITLE
Display the "Tune Link" field if set

### DIFF
--- a/_includes/layouts/song.njk
+++ b/_includes/layouts/song.njk
@@ -8,6 +8,7 @@ templateEngineOverride: njk,md
   <h1>{{ songNumber}} - {{ title }}</h1>
 {% if wordsBy %}<small>Words: {{ wordsBy }}</small><br />{% endif %}
 {% if tuneBy %}<small>Tune: {{ tuneBy }}</small>{% endif %}
+{% if tuneLink %}<small>Song/Tune Link: {{ tuneLink }}</small>{% endif %}
   <p>
 {% if description %}
 <div class="message is-info">

--- a/songs/Mary-Ellen-Carter.md
+++ b/songs/Mary-Ellen-Carter.md
@@ -6,7 +6,6 @@ wordsBy: © Stan Rogers
 tuneBy: © Stan Rogers
 chorusLine: 'Rise again'
 songLine: 'Make the Mary Ellen Carter rise again'
-tuneLink: ''
 tags:
   - song
   - ship

--- a/songs/broadside-broadside.md
+++ b/songs/broadside-broadside.md
@@ -6,7 +6,6 @@ wordsBy: © Nancy Kerr
 tuneBy: '© Nancy Kerr, John Smith, Martin Simpson'
 chorusLine: 'Broadside to broadside, two captains collide'
 songLine: 'Keep your land you gentry of England, France and Spain'
-tuneLink: ''
 tags:
   - non-male_writer
   - seafaring_women

--- a/songs/female-sailor-bold-female-sailor-bold.md
+++ b/songs/female-sailor-bold-female-sailor-bold.md
@@ -5,7 +5,6 @@ published: true
 wordsBy: Traditional
 tuneBy: Traditional
 songLine: 'Come, all ye good people, and listen to my song'
-tuneLink: ''
 tags:
   - song
   - seafaring_women

--- a/songs/the-last-oxonian-pirate.md
+++ b/songs/the-last-oxonian-pirate.md
@@ -6,7 +6,6 @@ wordsBy: The Arrogant Worms / Libbi Wittenberg
 tuneBy: © The Arrogant Worms
 chorusLine: And it's a heave! ho! hi! ho! Cycling round the Plain
 songLine: 'I used to be a tutor, and I made a living fine'
-tuneLink: 
 tags:
   - song
   - parody

--- a/songs/three-jolly-fishermen.md
+++ b/songs/three-jolly-fishermen.md
@@ -6,7 +6,6 @@ wordsBy: Traditional
 tuneBy: Traditional
 chorusLine: Make haste, make haste, you'll be too late
 songLine: 'My bonny silver herring'
-tuneLink: ''
 tags:
   - song
   - more_chorus_than_verse


### PR DESCRIPTION
A handful of songs have links which can be used to provide a link to a recording or other such useful link (ostensibly used to give you help with a tune going by the name - but it can link to anything). Anyway I noticed the option to show it wasn't enabled, so i've enabled it. I've removed a few places where the tuneLink was blank.